### PR TITLE
iOS Safari プレビュー: 遠い future video の prewarm を直近候補に制限

### DIFF
--- a/.agents/skills/turtle-video-overview/references/implementation-patterns.md
+++ b/.agents/skills/turtle-video-overview/references/implementation-patterns.md
@@ -19,6 +19,20 @@
   - iOS Safari では `canplay` 自体が遅延到達することがあるため、listener を外すだけでは不十分で、発火後の no-op ガードが必要
   - timeout fallback で `play()` を再試行する場合も同じ世代 helper を使わないと、seek 直後の race が再発する
 
+
+### 0-2. iOS Safari preview の future video prewarm は「画像区間中の次動画」を例外維持する
+
+- **ファイル**: `src/components/TurtleVideo.tsx`, `src/utils/previewPlatform.ts`, `src/test/previewPlatform.test.ts`
+- **背景**:
+  - 遠い future video の prewarm を一律 `0.35s` に制限すると、画像クリップが 350ms を超える一般的なタイムラインで次動画が事前 `play()` 対象から外れる
+  - `renderFrame()` は対象外になった inactive video を `pause()` するだけで、後から lead window に入っても rAF 外で再 prime されないため、iOS Safari の gesture credit を失った `play()` に逆戻りしやすい
+- **実装指針**:
+  - `shouldKeepInactiveVideoPrewarmed()` では、通常は lead window で future video を絞りつつ、**現在が画像/無動画区間で、かつ最も近い次動画** だけは距離に関係なく prewarm 維持を許可する
+  - `startEngine()` / seek 再開 (`proceedWithPlayback`) / `renderFrame()` で同じ「最も近い future video」判定を共有し、初回 prime と維持判定が食い違わないようにする
+- **注意点**:
+  - 例外維持を許可するのは次動画 1 本だけに留め、2 本目以降の future video まで走らせない
+  - active video 再生中まで例外を広げると、元の「遠い future video が BGM と競合する」問題を再発させやすい
+
 ## 1. スクロール/スワイプ誤操作防止
 
 ### 1-1. モーダル表示時のボディスクロールロック

--- a/src/components/TurtleVideo.tsx
+++ b/src/components/TurtleVideo.tsx
@@ -711,6 +711,19 @@ const TurtleVideo: React.FC = () => {
           }
         }
 
+        const allowExtendedFutureVideoPrewarm = !activeId || currentItems[activeIndex]?.type !== 'video';
+        let nearestFutureVideoId: string | null = null;
+        for (const item of currentItems) {
+          const timelineRange = timelineRanges.get(item.id);
+          if (!timelineRange || item.type !== 'video') {
+            continue;
+          }
+          if (timelineRange.start - time > 0.0005) {
+            nearestFutureVideoId = item.id;
+            break;
+          }
+        }
+
         Object.keys(mediaElementsRef.current).forEach((id) => {
           if (id === 'bgm' || id.startsWith('narration:')) return;
 
@@ -967,6 +980,8 @@ const TurtleVideo: React.FC = () => {
                 isActivePlaying,
                 timeSinceVideoEndSec,
                 timeUntilVideoStartSec,
+                isNearestFutureVideo: id === nearestFutureVideoId,
+                allowExtendedFuturePrewarm: allowExtendedFutureVideoPrewarm,
               });
               if (!shouldKeepVideoPrewarmed && !videoEl.paused) {
                 videoEl.pause();
@@ -3621,7 +3636,21 @@ const TurtleVideo: React.FC = () => {
         // AudioSession 破壊で BGM が無音化する原因になる。
         // ここで play() しておけば、renderFrame では pause/play 不要になる。
         if (previewPlatformPolicy.muteNativeMediaWhenAudioRouted) {
+          const allowExtendedFuturePrewarm = preparedPreviewAudio.activeVideoId === null;
+          let nearestFutureVideoId: string | null = null;
           let prewarmCursor = 0;
+          for (const item of mediaItemsRef.current) {
+            const itemStart = prewarmCursor;
+            const itemEnd = prewarmCursor + Math.max(0, item.duration);
+            prewarmCursor = itemEnd;
+            if (item.type !== 'video') continue;
+            if (itemStart - fromTime > 0.0005) {
+              nearestFutureVideoId = item.id;
+              break;
+            }
+          }
+
+          prewarmCursor = 0;
           for (const item of mediaItemsRef.current) {
             const itemStart = prewarmCursor;
             const itemEnd = prewarmCursor + Math.max(0, item.duration);
@@ -3637,6 +3666,8 @@ const TurtleVideo: React.FC = () => {
               isActivePlaying: true,
               timeSinceVideoEndSec: fromTime - itemEnd,
               timeUntilVideoStartSec: itemStart - fromTime,
+              isNearestFutureVideo: item.id === nearestFutureVideoId,
+              allowExtendedFuturePrewarm,
             });
             if (!shouldPrewarmVideo) {
               continue;
@@ -4450,7 +4481,21 @@ const TurtleVideo: React.FC = () => {
         // 非アクティブなビデオを事前 play() する。startEngine と同じ目的で、
         // renderFrame 内での play() 呼び出しを回避する。
         if (previewPlatformPolicy.muteNativeMediaWhenAudioRouted) {
+          const allowExtendedFuturePrewarm = preparedPreviewAudio.activeVideoId === null;
+          let nearestFutureVideoId: string | null = null;
           let prewarmCursor = 0;
+          for (const item of mediaItemsRef.current) {
+            const itemStart = prewarmCursor;
+            const itemEnd = prewarmCursor + Math.max(0, item.duration);
+            prewarmCursor = itemEnd;
+            if (item.type !== 'video') continue;
+            if (itemStart - playbackTime > 0.0005) {
+              nearestFutureVideoId = item.id;
+              break;
+            }
+          }
+
+          prewarmCursor = 0;
           for (const item of mediaItemsRef.current) {
             const itemStart = prewarmCursor;
             const itemEnd = prewarmCursor + Math.max(0, item.duration);
@@ -4466,6 +4511,8 @@ const TurtleVideo: React.FC = () => {
               isActivePlaying: true,
               timeSinceVideoEndSec: playbackTime - itemEnd,
               timeUntilVideoStartSec: itemStart - playbackTime,
+              isNearestFutureVideo: item.id === nearestFutureVideoId,
+              allowExtendedFuturePrewarm,
             });
             if (!shouldPrewarmVideo) {
               continue;

--- a/src/test/previewPlatform.test.ts
+++ b/src/test/previewPlatform.test.ts
@@ -162,6 +162,38 @@ describe('getPreviewPlatformPolicy', () => {
     ).toBe(false);
   });
 
+  it('画像区間中は次の動画だけ距離に関わらず prewarm を維持できる', () => {
+    const iosPolicy = getPreviewPlatformPolicy({
+      isAndroid: false,
+      isIosSafari: true,
+      audioContextMayInterrupt: true,
+    });
+
+    expect(
+      shouldKeepInactiveVideoPrewarmed(iosPolicy, {
+        hasAudioNode: true,
+        isExporting: false,
+        isActivePlaying: true,
+        timeSinceVideoEndSec: -3,
+        timeUntilVideoStartSec: 1.5,
+        isNearestFutureVideo: true,
+        allowExtendedFuturePrewarm: true,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldKeepInactiveVideoPrewarmed(iosPolicy, {
+        hasAudioNode: true,
+        isExporting: false,
+        isActivePlaying: true,
+        timeSinceVideoEndSec: -6,
+        timeUntilVideoStartSec: 3.5,
+        isNearestFutureVideo: false,
+        allowExtendedFuturePrewarm: true,
+      }),
+    ).toBe(false);
+  });
+
   it('非 iOS や非再生中では inactive video を prewarm 維持しない', () => {
     const iosPolicy = getPreviewPlatformPolicy({
       isAndroid: false,

--- a/src/utils/previewPlatform.ts
+++ b/src/utils/previewPlatform.ts
@@ -135,17 +135,26 @@ export function shouldKeepInactiveVideoPrewarmed(
     timeUntilVideoStartSec?: number | null;
     pauseGraceSec?: number;
     prewarmLeadSec?: number;
+    isNearestFutureVideo?: boolean;
+    allowExtendedFuturePrewarm?: boolean;
   },
 ): boolean {
   const pauseGraceSec = options.pauseGraceSec ?? 0.25;
   const prewarmLeadSec = options.prewarmLeadSec ?? 0.35;
+  const shouldAllowExtendedFuturePrewarm =
+    options.allowExtendedFuturePrewarm
+    && options.isNearestFutureVideo
+    && options.timeUntilVideoStartSec !== null
+    && options.timeUntilVideoStartSec !== undefined
+    && options.timeUntilVideoStartSec >= 0;
   const isPastVideoBeyondGrace =
     options.timeSinceVideoEndSec !== null
     && options.timeSinceVideoEndSec >= pauseGraceSec;
   const isFutureVideoTooFar =
     options.timeUntilVideoStartSec !== null
     && options.timeUntilVideoStartSec !== undefined
-    && options.timeUntilVideoStartSec > prewarmLeadSec;
+    && options.timeUntilVideoStartSec > prewarmLeadSec
+    && !shouldAllowExtendedFuturePrewarm;
 
   return options.hasAudioNode
     && policy.muteNativeMediaWhenAudioRouted


### PR DESCRIPTION
### Motivation
- iOS Safari のプレビューで BGM と動画を同時に扱うと、遠い将来の video まで無音で `play()` してしまい再生競合や音飛びが発生しやすかったため、最低限確実に再生できる状態を優先する必要があった。

### Description
- `shouldKeepInactiveVideoPrewarmed()` に `timeUntilVideoStartSec` と `prewarmLeadSec` を追加して、遠い future video を prewarm 対象から除外する判定を導入した。 
- `src/components/TurtleVideo.tsx` のレンダーループ、`startEngine()` と seek 再開時の事前 `play()` ループで新しい判定を利用するようにし、直近の切替候補だけを無音 prewarm するように制御を変更した。 
- `src/test/previewPlatform.test.ts` に遠い将来の video を prewarm しないケースの回帰テストを追加した。 
- 実装方針を示すドキュメント（overview の `implementation-patterns.md`）に今回のガード方針を追記した。 
- 変更対象ファイル: `src/utils/previewPlatform.ts`, `src/components/TurtleVideo.tsx`, `src/test/previewPlatform.test.ts`, `.agents/skills/turtle-video-overview/references/implementation-patterns.md`。

### Testing
- 変更後に `npm run test:run` を実行し、テストスイートは `205 tests passed (27 files)` の全件成功となった。 
- `npm run build` を実行し、ビルドは問題なく成功した。 
- 追加した単体テスト `src/test/previewPlatform.test.ts` は成功しており、回帰がないことを確認した。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69be39a5058483259db13484d6d3a6fc)