### PR TITLE
自動保存の再開漏れ修正と OfflineAudioContext の iOS 限定化

### DIFF
--- a/.agents/skills/turtle-video-overview/references/implementation-patterns.md
+++ b/.agents/skills/turtle-video-overview/references/implementation-patterns.md
@@ -1446,3 +1446,32 @@
 - **注意**:
   - lead window を広げすぎると再び「遠い future video まで走る」状態へ戻り、狭めすぎると画像区間→動画区間の立ち上がりが悪化する
   - iOS Safari preview の安定性を優先する場合は、「すべてを滑らかにする」より「今必要な video だけ確実に鳴らす」方針を維持する
+
+### 13-75. 自動保存の経過判定は『実際に保存を再開できる時刻』を基準にし、export 見送り後は即 catch-up する
+
+- **ファイル**: `src/hooks/useAutoSave.ts`
+- **問題**:
+  - 自動保存タイマーの tick 時点で export 中だと保存自体は見送るが、その時刻を次回判定基準にしてしまうと、export 終了後も次の1周期が来るまで保存が再開されない
+  - Android / PC では長めの export や復帰操作のあとに「1分設定でもいつまでも auto save されない」体感につながりやすい
+- **対策**:
+  - 自動保存の経過判定は `lastAutoSaveActivityAtRef` のような『実際に保存可能だった最新時刻』で管理し、`skipped-processing` では更新しない
+  - `isProcessing` が `true -> false` に戻った直後、かつ保存間隔を超過していれば短い遅延で catch-up save を実行する
+  - `visibilitychange` / `focus` / `pageshow` 復帰時も同じ基準で overdue 判定し、hidden 中の見送りを持ち越さない
+- **注意**:
+  - export 中だけ保存を避け、通常の no-change / empty 判定では基準時刻を更新して次周期までの待機へ戻す
+  - iOS Safari preview の再生制御とは分離し、保存再開ロジックだけを `useAutoSave.ts` に閉じる
+
+### 13-76. `OfflineAudioContext` の先行プリレンダリング条件は resolver で iOS Safari に限定する
+
+- **ファイル**: `src/hooks/export-strategies/exportStrategyResolver.ts`, `src/hooks/useExport.ts`, `src/test/exportStrategyResolver.test.ts`
+- **問題**:
+  - Safari 向け回避策のはずの `OfflineAudioContext` 事前レンダリング条件が `hasAudioSources` だけだと、Android / PC でも常に音声準備待ちが入って export 準備時間が長くなる
+  - 条件が hook 本体に散ると、iOS Safari 専用の責務境界が崩れて再発しやすい
+- **対策**:
+  - `shouldUseOfflineAudioPreRender()` の入力に `isIosSafari` を含め、`isIosSafari && hasAudioSources` のときだけ true を返す
+  - `useExport.ts` 側は resolver の結果だけを参照し、Android / PC は従来どおり WebCodecs のリアルタイム音声キャプチャ経路へ進める
+  - resolver の pure logic をテストで固定し、非iOSへの漏れを自動検知する
+- **注意**:
+  - iOS Safari export の音声安定化には必要なため、条件を削るのではなく resolver へ閉じ込めて platform 分岐を明示する
+  - preview 側の iOS Safari workaround と混線させず、export strategy の責務として維持する
+

--- a/src/hooks/export-strategies/exportStrategyResolver.ts
+++ b/src/hooks/export-strategies/exportStrategyResolver.ts
@@ -18,12 +18,13 @@ export function resolveExportStrategyOrder(
 
 export interface OfflineAudioPreRenderResolutionInput {
   hasAudioSources: boolean;
+  isIosSafari: boolean;
 }
 
 export function shouldUseOfflineAudioPreRender(
   input: OfflineAudioPreRenderResolutionInput,
 ): boolean {
-  return input.hasAudioSources;
+  return input.isIosSafari && input.hasAudioSources;
 }
 
 export type WebCodecsAudioCaptureStrategy =

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -23,6 +23,8 @@ export type AutoSaveIntervalOption = 0 | 1 | 2 | 5;
 export const DEFAULT_AUTO_SAVE_INTERVAL: AutoSaveIntervalOption = 2;
 const AUTO_SAVE_RETURN_CHECK_DELAY_MS = 80;
 
+type AutoSaveRunResult = 'saved' | 'skipped-processing' | 'skipped-nochange' | 'skipped-empty';
+
 function isAutoSaveIntervalOption(value: number): value is AutoSaveIntervalOption {
   return value === 0 || value === 1 || value === 2 || value === 5;
 }
@@ -69,9 +71,9 @@ export function useAutoSave() {
   const intervalRef = useRef<number | null>(null);
   const catchUpSaveTimeoutRef = useRef<number | null>(null);
   const lastSaveHashRef = useRef<string>('');
-  const performAutoSaveRef = useRef<() => Promise<void>>(async () => {});
+  const performAutoSaveRef = useRef<() => Promise<AutoSaveRunResult>>(async () => 'skipped-empty');
   const isAutoSaveRunningRef = useRef(false);
-  const lastAutoSaveAttemptAtRef = useRef<number>(Date.now());
+  const lastAutoSaveActivityAtRef = useRef<number>(Date.now());
   const [autoSaveMinutes, setAutoSaveMinutes] = useState<AutoSaveIntervalOption>(getAutoSaveInterval);
   
   // ストアからデータを取得
@@ -189,22 +191,22 @@ export function useAutoSave() {
   /**
    * 自動保存を実行
    */
-  const performAutoSave = useCallback(async () => {
+  const performAutoSave = useCallback(async (): Promise<AutoSaveRunResult> => {
     // エクスポート中は保存をスキップ（動画品質を保護）
     if (isProcessing) {
-      return;
+      return 'skipped-processing';
     }
     
     const currentHash = computeHash();
     
     // 変更がない場合はスキップ
     if (currentHash === lastSaveHashRef.current) {
-      return;
+      return 'skipped-nochange';
     }
     
     // データがない場合はスキップ
     if (mediaItems.length === 0 && !bgm && narrations.length === 0 && captions.length === 0) {
-      return;
+      return 'skipped-empty';
     }
     
     await saveProjectAuto(
@@ -226,6 +228,7 @@ export function useAutoSave() {
     });
     
     lastSaveHashRef.current = currentHash;
+    return 'saved';
   }, [
     computeHash,
     mediaItems,
@@ -250,9 +253,11 @@ export function useAutoSave() {
     if (isAutoSaveRunningRef.current) return;
 
     isAutoSaveRunningRef.current = true;
-    lastAutoSaveAttemptAtRef.current = Date.now();
     try {
-      await performAutoSaveRef.current();
+      const result = await performAutoSaveRef.current();
+      if (result !== 'skipped-processing') {
+        lastAutoSaveActivityAtRef.current = Date.now();
+      }
     } finally {
       isAutoSaveRunningRef.current = false;
     }
@@ -262,7 +267,7 @@ export function useAutoSave() {
     if (!lastManualSave) return;
     // 手動保存直後は同一内容が保存済みなので、自動保存の差分ベースラインも更新する。
     lastSaveHashRef.current = computeHash();
-    lastAutoSaveAttemptAtRef.current = Date.now();
+    lastAutoSaveActivityAtRef.current = Date.now();
   }, [lastManualSave, computeHash]);
 
   // 保存間隔の更新を即時反映（同一タブ + 他タブ）
@@ -297,20 +302,8 @@ export function useAutoSave() {
     const initTimeout = window.setTimeout(() => {
       useProjectStore.getState().refreshSaveInfo();
     }, 1000);
-    
-    // オフの場合はタイマーを設定しない
-    if (autoSaveMinutes === 0) {
-      return () => {
-        clearTimeout(initTimeout);
-      };
-    }
-    
-    // 自動保存タイマー開始
+
     const intervalMs = autoSaveMinutes * 60 * 1000;
-    lastAutoSaveAttemptAtRef.current = Date.now();
-    intervalRef.current = window.setInterval(() => {
-      void runAutoSave();
-    }, intervalMs);
 
     const clearScheduledCatchUpSave = () => {
       if (catchUpSaveTimeoutRef.current !== null) {
@@ -327,11 +320,24 @@ export function useAutoSave() {
         catchUpSaveTimeoutRef.current = null;
         if (document.visibilityState === 'hidden') return;
         if (useProjectStore.getState().isSaving) return;
-        const elapsed = Date.now() - lastAutoSaveAttemptAtRef.current;
+        const elapsed = Date.now() - lastAutoSaveActivityAtRef.current;
         if (elapsed < intervalMs) return;
         void runAutoSave();
       }, AUTO_SAVE_RETURN_CHECK_DELAY_MS);
     };
+    
+    // オフの場合はタイマーを設定しない
+    if (autoSaveMinutes === 0) {
+      return () => {
+        clearTimeout(initTimeout);
+      };
+    }
+    
+    // 自動保存タイマー開始
+    lastAutoSaveActivityAtRef.current = Date.now();
+    intervalRef.current = window.setInterval(() => {
+      void runAutoSave();
+    }, intervalMs);
 
     document.addEventListener('visibilitychange', triggerCatchUpSave);
     window.addEventListener('focus', triggerCatchUpSave);
@@ -349,6 +355,26 @@ export function useAutoSave() {
     };
   }, [autoSaveMinutes, runAutoSave]);
   
+  useEffect(() => {
+    if (autoSaveMinutes === 0) return;
+    if (isProcessing) return;
+    if (document.visibilityState === 'hidden') return;
+
+    const intervalMs = autoSaveMinutes * 60 * 1000;
+    const elapsed = Date.now() - lastAutoSaveActivityAtRef.current;
+    if (elapsed < intervalMs) return;
+
+    const timeoutId = window.setTimeout(() => {
+      if (document.visibilityState === 'hidden') return;
+      if (useProjectStore.getState().isSaving) return;
+      void runAutoSave();
+    }, AUTO_SAVE_RETURN_CHECK_DELAY_MS);
+
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, [autoSaveMinutes, isProcessing, runAutoSave]);
+
   /**
    * 自動保存間隔を更新
    */

--- a/src/hooks/useExport.ts
+++ b/src/hooks/useExport.ts
@@ -968,6 +968,7 @@ export function useExport(): UseExportReturn {
 
         const shouldPreRenderAudio = shouldUseOfflineAudioPreRender({
           hasAudioSources: !!audioSources,
+          isIosSafari,
         });
         if (!shouldPreRenderAudio || !audioSources) {
           return null;
@@ -1210,6 +1211,7 @@ export function useExport(): UseExportReturn {
         let offlineAudioDone = false;
         const shouldPreRenderAudio = shouldUseOfflineAudioPreRender({
           hasAudioSources: !!audioSources,
+          isIosSafari,
         });
         if (shouldPreRenderAudio && audioSources) {
           const renderedAudio = await ensurePreRenderedAudioBuffer();

--- a/src/test/exportStrategyResolver.test.ts
+++ b/src/test/exportStrategyResolver.test.ts
@@ -91,6 +91,7 @@ describe('shouldUseOfflineAudioPreRender', () => {
     expect(
       shouldUseOfflineAudioPreRender({
         hasAudioSources: true,
+        isIosSafari: true,
       }),
     ).toBe(true);
   });
@@ -99,14 +100,16 @@ describe('shouldUseOfflineAudioPreRender', () => {
     expect(
       shouldUseOfflineAudioPreRender({
         hasAudioSources: true,
+        isIosSafari: false,
       }),
-    ).toBe(true);
+    ).toBe(false);
   });
 
   it('iOS Safari でも音声ソースが無ければ OfflineAudioContext を使わない', () => {
     expect(
       shouldUseOfflineAudioPreRender({
         hasAudioSources: false,
+        isIosSafari: true,
       }),
     ).toBe(false);
   });

--- a/src/test/useAutoSave.test.tsx
+++ b/src/test/useAutoSave.test.tsx
@@ -165,6 +165,41 @@ describe('useAutoSave', () => {
     expect(saveProjectAuto).not.toHaveBeenCalled();
   });
 
+  it('エクスポート中に見送った自動保存は、処理終了後に即座に再開する', async () => {
+    const refreshSaveInfo = vi.fn().mockResolvedValue(undefined);
+    const saveProjectAuto = vi.fn().mockResolvedValue(undefined);
+    act(() => {
+      useProjectStore.setState({
+        refreshSaveInfo,
+        saveProjectAuto,
+        isSaving: false,
+        lastManualSave: null,
+      });
+      useUIStore.setState({ isProcessing: true });
+    });
+
+    renderHook(() => useAutoSave());
+
+    await act(async () => {
+      vi.advanceTimersByTime(61_000);
+      await Promise.resolve();
+    });
+
+    expect(saveProjectAuto).not.toHaveBeenCalled();
+
+    await act(async () => {
+      useUIStore.setState({ isProcessing: false });
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(100);
+      await Promise.resolve();
+    });
+
+    expect(saveProjectAuto).toHaveBeenCalledTimes(1);
+  });
+
   it('トリム後の位置・サイズ調整も自動保存の差分として検知する', async () => {
     const refreshSaveInfo = vi.fn().mockResolvedValue(undefined);
     const saveProjectAuto = vi.fn().mockResolvedValue(undefined);


### PR DESCRIPTION
### Motivation
- Android/PC で自動保存がエクスポート中にスキップされた後にいつまでも再開されない報告に対処するための修正を行いました。 
- さらに、iOS Safari 向けの `OfflineAudioContext` による事前音声プリレンダリングが非iOS環境へ波及し、エクスポート準備時間が長くなっていたため、これをプラットフォーム限定で切り分けます。 
- iOS Safari の既存の preview 再生ロジックに影響を与えないよう、責務を明確に分離しました。 

### Description
- `src/hooks/useAutoSave.ts` にて自動保存の実行結果を分類する `AutoSaveRunResult` を導入し、`skipped-processing`（エクスポート中に見送ったケース）では「最後に保存可能だった時刻」を更新しないようにしました。 
- `useAutoSave` 内で `lastAutoSaveActivityAtRef` を導入し、エクスポート終了直後や `visibilitychange` / `focus` / `pageshow` の復帰時に保存間隔を超過していれば短遅延で catch-up 保存を実行するフォールバックを追加しました。 
- `src/hooks/export-strategies/exportStrategyResolver.ts` の `shouldUseOfflineAudioPreRender` に `isIosSafari` 引数を追加して判定を `isIosSafari && hasAudioSources` に変更し、iOS Safari のみで OfflineAudioContext パスを使うように制限しました。 
- `src/hooks/useExport.ts` 側からは resolver の結果を参照する形にし、`isIosSafari` を渡す修正を行いました。 
- 回帰検知のためにテストを追加・更新しました：`src/test/useAutoSave.test.tsx` に export 中見送り後の再開テストを追加、`src/test/exportStrategyResolver.test.ts` を iOS/非iOSケースに合わせて更新しました。 
- オーバービュー（`.agents/skills/turtle-video-overview/references/implementation-patterns.md`）に今回の注意点（自動保存判定・OfflineAudioContext 条件）を追記しました。 

### Testing
- 実行したコマンド: `npm run test:run -- src/test/useAutoSave.test.tsx src/test/exportStrategyResolver.test.ts` の単体実行は成功しました（追加テスト含む）。
- 続けて `npm run test:run` による全テストを実行し、全てのテストが合格しました（例: `Test Files 28 passed / Tests 211 passed`）。
- 最後に `npm run build` を実行し、ビルドが正常終了しました。
- 以上の自動テスト・ビルドはすべて成功しています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf91793db883258a63520f2b651258)