### PR TITLE
Fix initial auto-save slot creation

### DIFF
--- a/.agents/skills/turtle-video-overview/references/implementation-patterns.md
+++ b/.agents/skills/turtle-video-overview/references/implementation-patterns.md
@@ -1475,3 +1475,15 @@
   - iOS Safari export の音声安定化には必要なため、条件を削るのではなく resolver へ閉じ込めて platform 分岐を明示する
   - preview 側の iOS Safari workaround と混線させず、export strategy の責務として維持する
 
+### 13-77. 初回 auto save は manual save 直後でも auto slot 未作成なら 1 回は実行する
+
+- **ファイル**: `src/hooks/useAutoSave.ts`, `src/test/useAutoSave.test.tsx`
+- **問題**:
+  - manual save 直後に差分ベースラインだけ更新すると、内容が変わっていない限り `skipped-nochange` が続き、auto save スロット自体が一度も作られない
+  - 保存モーダル上では「自動保存」が `---` のまま残り、1 分設定でも動いていないように見える
+- **対策**:
+  - `lastAutoSave === null` の間は no-change 最適化を外し、manual save と同内容でも最初の auto save を 1 回だけ作成する
+  - auto slot 作成後は従来どおり差分ベースの no-change スキップへ戻す
+- **注意**:
+  - 「内容が変わっていないときに毎回 auto save する」わけではなく、対象は auto slot 未作成時の初回だけに限定する
+  - `isProcessing` や hidden 復帰の catch-up 判定とは別責務として、auto slot の初期生成可否だけをこの条件で制御する

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -91,6 +91,7 @@ export function useAutoSave() {
   const isProcessing = useUIStore((s) => s.isProcessing);
   
   const saveProjectAuto = useProjectStore((s) => s.saveProjectAuto);
+  const lastAutoSave = useProjectStore((s) => s.lastAutoSave);
   const lastManualSave = useProjectStore((s) => s.lastManualSave);
   
   /**
@@ -200,7 +201,7 @@ export function useAutoSave() {
     const currentHash = computeHash();
     
     // 変更がない場合はスキップ
-    if (currentHash === lastSaveHashRef.current) {
+    if (currentHash === lastSaveHashRef.current && lastAutoSave) {
       return 'skipped-nochange';
     }
     
@@ -242,6 +243,7 @@ export function useAutoSave() {
     isCaptionsLocked,
     isProcessing,
     saveProjectAuto,
+    lastAutoSave,
   ]);
 
   useEffect(() => {

--- a/src/test/useAutoSave.test.tsx
+++ b/src/test/useAutoSave.test.tsx
@@ -97,6 +97,7 @@ describe('useAutoSave', () => {
         saveProjectAuto,
         isSaving: false,
         lastManualSave: null,
+        lastAutoSave: '2026-03-16T23:59:00.000Z',
       });
     });
 
@@ -128,6 +129,7 @@ describe('useAutoSave', () => {
         saveProjectAuto,
         isSaving: false,
         lastManualSave: null,
+        lastAutoSave: '2026-03-16T23:59:00.000Z',
       });
     });
 
@@ -163,6 +165,42 @@ describe('useAutoSave', () => {
     });
 
     expect(saveProjectAuto).not.toHaveBeenCalled();
+  });
+
+  it('auto save スロットが未作成なら、手動保存直後でも初回の自動保存を1回は作成する', async () => {
+    const refreshSaveInfo = vi.fn().mockResolvedValue(undefined);
+    const saveProjectAuto = vi.fn().mockResolvedValue(undefined);
+    act(() => {
+      useProjectStore.setState({
+        refreshSaveInfo,
+        saveProjectAuto,
+        isSaving: false,
+        lastManualSave: '2026-03-17T00:00:00.000Z',
+        lastAutoSave: null,
+      });
+    });
+
+    renderHook(() => useAutoSave());
+
+    await act(async () => {
+      vi.advanceTimersByTime(61_000);
+      await Promise.resolve();
+    });
+
+    expect(saveProjectAuto).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      useProjectStore.setState({
+        lastAutoSave: '2026-03-17T00:01:01.000Z',
+      });
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(61_000);
+      await Promise.resolve();
+    });
+
+    expect(saveProjectAuto).toHaveBeenCalledTimes(1);
   });
 
   it('エクスポート中に見送った自動保存は、処理終了後に即座に再開する', async () => {


### PR DESCRIPTION
### Motivation
- 自動保存を1分に設定しても保存モーダルの「自動保存」が `---` のまま更新されない不具合を修正するための変更です。
- 原因は手動保存後に `lastSaveHashRef` を更新して差分検出で `skipped-nochange` になり、`auto` スロットが未作成でも初回の自動保存が一度も走らない経路が存在したことです。

### Description
- `src/hooks/useAutoSave.ts` に `lastAutoSave` を参照するセレクタを追加し、自動保存の `no-change` 判定を `lastAutoSave` が存在する場合にのみ適用するよう変更しました（未作成の場合は初回で `auto` スロットを作成する）。
- `src/test/useAutoSave.test.tsx` に回帰テストを追加し、`auto` スロット未作成時に手動保存直後でも初回自動保存が1回作成されることと、既存 `auto` がある場合の従来挙動を検証するテストを追加しました。
- ドキュメント（`.agents/skills/turtle-video-overview/references/implementation-patterns.md`）へ今回の注意点（初回 auto save の扱い）を追記しました。

### Testing
- 単体：`npm run test:run -- src/test/useAutoSave.test.tsx` を実行し該当テストが通過しました。  
- フルテスト：`npm run test:run` を実行し、プロジェクトのテストスイート全体が通過（212 件のテストが全て成功）しました。  
- ビルド：`npm run build` を実行し、TypeScript コンパイルと Vite ビルドが成功しました（ビルド警告は出ていますがビルド自体は成功しています）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfa083aeb883259dccbec39613a302)