### PR TITLE
フェード終端で最終フレームが露出する問題を修正

### DIFF
--- a/.agents/skills/turtle-video-overview/references/implementation-patterns.md
+++ b/.agents/skills/turtle-video-overview/references/implementation-patterns.md
@@ -1503,3 +1503,16 @@
 - **注意**:
   - iOS Safari export の音声安定化には必要なため、条件を削るのではなく resolver へ閉じ込めて platform 分岐を明示する
   - preview 側の iOS Safari workaround と混線させず、export strategy の責務として維持する
+
+### 13-77. フェードアウト終端で動画フレームが欠けたら hold より黒クリアを優先する
+
+- **ファイル**: `src/components/TurtleVideo.tsx`, `src/utils/previewPlatform.ts`, `src/test/previewPlatform.test.ts`
+- **問題**:
+  - Android / PC では、トリミング済み動画のフェードアウト終端でデコーダが最後の `seeked` / `ended` に寄ると、`holdFrame` が直前の可視フレームを保持してしまい「黒へ落ち切る直前に最終フレームが残る」ことがある
+  - このとき audio routing や native mute を触ると、過去に対策した Teams 共有時の遅延回避まで壊すリスクがある
+- **対策**:
+  - `shouldBlackoutVideoFadeTail()` で「fade alpha がほぼ 0 の tail」だけを pure に判定し、その区間でフレーム未確定なら `holdFrame` ではなくキャンバス黒クリアを優先する
+  - 修正は `renderFrame()` の描画判定に閉じ、既存の `shouldHoldVideoFrameAtClipEnd()` / audio node / native mute 制御は変更しない
+- **注意**:
+  - フェード中盤まで黒クリアへ倒すと、正当なフェード途中フレームまで欠けて見えるため、alpha が十分下がった末尾だけに限定する
+  - Teams 向けの muted / WebAudio 経路は既存 helper に委ね、描画不具合の修正を音声制御へ波及させない

--- a/src/components/TurtleVideo.tsx
+++ b/src/components/TurtleVideo.tsx
@@ -40,6 +40,7 @@ import {
   getPreviewVideoSyncThreshold,
   getPageHidePausePlan,
   shouldAttemptDeferredPreviewPlay,
+  shouldBlackoutVideoFadeTail,
   shouldBundlePreviewStartForWebAudioMix,
   getVisibilityRecoveryPlan,
   shouldHoldVideoFrameAtClipEnd,
@@ -547,12 +548,24 @@ const TurtleVideo: React.FC = () => {
         // アクティブな動画が未準備の場合はキャンバスをクリアせず、
         // 直前フレームを保持してブラックアウトを防止
         let holdFrame = false;
+        let shouldBlackoutFadeTail = false;
         if (activeId && activeIndex !== -1) {
           const activeItem = currentItems[activeIndex];
+          const shouldPreferBlackoutAtFadeTail = shouldBlackoutVideoFadeTail({
+            clipLocalTime: localTime,
+            clipDuration: activeItem.duration,
+            fadeOut: activeItem.fadeOut,
+            fadeOutDuration: activeItem.fadeOutDuration || 1.0,
+          });
+
           if (activeItem.type === 'video') {
             const activeEl = mediaElementsRef.current[activeId] as HTMLVideoElement | undefined;
             if (!activeEl) {
-              holdFrame = true;
+              if (shouldPreferBlackoutAtFadeTail) {
+                shouldBlackoutFadeTail = true;
+              } else {
+                holdFrame = true;
+              }
             } else {
               const targetTime = (activeItem.trimStart || 0) + localTime;
               const isLastTimelineItem = activeIndex === currentItems.length - 1;
@@ -616,9 +629,13 @@ const TurtleVideo: React.FC = () => {
               });
 
               if (!hasFrame || needsCorrection || shouldHoldForVideoEnd) {
-                holdFrame = true;
+                if (shouldPreferBlackoutAtFadeTail) {
+                  shouldBlackoutFadeTail = true;
+                } else {
+                  holdFrame = true;
+                }
                 // ブラックアウト防止発動をログ
-                logInfo('RENDER', 'フレーム保持発動', {
+                logInfo('RENDER', shouldPreferBlackoutAtFadeTail ? 'フェード終端ブラックアウト優先' : 'フレーム保持発動', {
                   videoId: activeId,
                   readyState: activeEl.readyState,
                   seeking: activeEl.seeking,
@@ -628,6 +645,7 @@ const TurtleVideo: React.FC = () => {
                   currentTime: time,
                   needsCorrection,
                   shouldHoldForVideoEnd,
+                  shouldBlackoutFadeTail: shouldPreferBlackoutAtFadeTail,
                 });
               }
             }
@@ -667,6 +685,7 @@ const TurtleVideo: React.FC = () => {
           _isExporting || (!isActivePlaying && !isPlayingRef.current)
         );
         const shouldClearCanvas = shouldForceStartClear
+          || shouldBlackoutFadeTail
           || (!holdFrame && !shouldHoldAtTimelineEnd && !shouldGuardNearEnd && !shouldGuardAfterFinalize);
 
         if (shouldClearCanvas) {

--- a/src/test/previewPlatform.test.ts
+++ b/src/test/previewPlatform.test.ts
@@ -8,6 +8,7 @@ import {
   getPreviewPlatformPolicy,
   getPreviewVideoSyncThreshold,
   shouldAttemptDeferredPreviewPlay,
+  shouldBlackoutVideoFadeTail,
   shouldBundlePreviewStartForWebAudioMix,
   shouldHoldVideoFrameAtClipEnd,
   shouldKeepInactiveVideoPrewarmed,
@@ -562,6 +563,39 @@ describe('preview platform helpers', () => {
         trimStart: 3,
         videoCurrentTime: 4.2,
         videoEnded: false,
+      }),
+    ).toBe(false);
+  });
+
+  it('フェード終端でほぼ黒になるはずの tail は保持より黒クリアを優先する', () => {
+    expect(
+      shouldBlackoutVideoFadeTail({
+        clipLocalTime: 1.98,
+        clipDuration: 2,
+        fadeOut: true,
+        fadeOutDuration: 1,
+      }),
+    ).toBe(true);
+  });
+
+  it('フェード中盤では従来どおりフレーム保持を許可する', () => {
+    expect(
+      shouldBlackoutVideoFadeTail({
+        clipLocalTime: 1.6,
+        clipDuration: 2,
+        fadeOut: true,
+        fadeOutDuration: 1,
+      }),
+    ).toBe(false);
+  });
+
+  it('フェードアウト未使用クリップでは黒クリアへ倒さない', () => {
+    expect(
+      shouldBlackoutVideoFadeTail({
+        clipLocalTime: 1.99,
+        clipDuration: 2,
+        fadeOut: false,
+        fadeOutDuration: 1,
       }),
     ).toBe(false);
   });

--- a/src/utils/previewPlatform.ts
+++ b/src/utils/previewPlatform.ts
@@ -66,6 +66,15 @@ export interface VideoClipEndGuardOptions {
   videoEndToleranceSec?: number;
 }
 
+
+export interface FadeTailBlackoutGuardOptions {
+  clipLocalTime: number;
+  clipDuration: number;
+  fadeOut: boolean;
+  fadeOutDuration: number;
+  blackoutAlphaThreshold?: number;
+}
+
 /**
  * プラットフォーム capability から、プレビュー制御用の方針を組み立てる。
  */
@@ -335,6 +344,29 @@ export function shouldHoldVideoFrameAtClipEnd(
 
   const safeClipEndTime = options.trimStart + Math.max(0, clipDuration - 0.001);
   return options.videoEnded || options.videoCurrentTime >= safeClipEndTime - videoEndToleranceSec;
+}
+
+/**
+ * フェードアウト終端で動画フレームを保持すると、低頻度で「黒へ落ち切る直前の最終フレーム」が残留する。
+ * ほぼ黒になるはずの tail では holdFrame より黒クリアを優先すべきかを返す。
+ */
+export function shouldBlackoutVideoFadeTail(
+  options: FadeTailBlackoutGuardOptions,
+): boolean {
+  if (!options.fadeOut) {
+    return false;
+  }
+
+  const clipDuration = Math.max(0, options.clipDuration);
+  const fadeOutDuration = Math.max(0, options.fadeOutDuration);
+  if (clipDuration <= 0 || fadeOutDuration <= 0) {
+    return false;
+  }
+
+  const remainingClipTime = Math.max(0, clipDuration - Math.max(0, options.clipLocalTime));
+  const fadeAlpha = Math.max(0, Math.min(1, remainingClipTime / fadeOutDuration));
+  const blackoutAlphaThreshold = options.blackoutAlphaThreshold ?? 0.05;
+  return fadeAlpha <= blackoutAlphaThreshold;
 }
 
 /**


### PR DESCRIPTION
### Motivation
- フェードアウト終端で稀に「黒へ落ち切る直前の最終フレーム」が保持されてしまい表示上の違和感を生むため、末尾の極端に低いアルファでは黒クリアを優先する必要があった。\n
### Description
- `src/utils/previewPlatform.ts` に `shouldBlackoutVideoFadeTail()` を追加し、フェード末尾（ほぼ透明な tail）かどうかを純粋関数で判定するようにした。\n- `src/components/TurtleVideo.tsx` の `renderFrame()` に判定を組み込み、該当区間では `holdFrame` ではなくキャンバスの黒クリアを優先するロジックを追加した（音声ルーティングや `shouldHoldVideoFrameAtClipEnd()` の既存ロジックには影響を与えないよう描画判定に限定）。\n- `src/test/previewPlatform.test.ts` に上記 helper の境界条件（末尾／中盤／非フェード）を検証するテストを追加した。\n- `.agents/skills/turtle-video-overview/references/implementation-patterns.md` に今回の回避策と「描画修正を音声制御へ波及させない」注意を書き加えた。\n
### Testing
- `npm run test:run -- src/test/previewPlatform.test.ts` を実行して追加したテストを含む該当テストはパスした（成功）。\n- `npm run test:run` でプロジェクト全体のテストを実行し、全テスト（218 件）が合格した（成功）。\n- `npm run build` を実行しビルド成功（Vite の chunk size 警告ありだがビルドは正常終了）。\n- `npm run lint` を実行し既存の警告は残るが新規エラーは発生していない（警告のみ）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bff824797c8325b230808483523a59)