### PR TITLE
Make OfflineAudioContext pre-rendering conditional and add fallback for empty real-time audio capture

### DIFF
--- a/.agents/skills/turtle-video-overview/references/implementation-patterns.md
+++ b/.agents/skills/turtle-video-overview/references/implementation-patterns.md
@@ -1517,3 +1517,18 @@
   - フェード中盤まで黒クリアへ倒すと、正当なフェード途中フレームまで欠けて見えるため、alpha が十分下がった末尾だけに限定する
   - Teams 向けの muted / WebAudio 経路は既存 helper に委ね、描画不具合の修正を音声制御へ波及させない
   - 末尾 tail に入ったら「フレーム欠落時だけ黒、取得できたら描画」にすると黒↔最終フレームが交互に出て点滅しやすい。terminal window に入ったら描画自体を黒へ揃え、終端品質を優先する
+
+### 13-78. export 音声の事前プリレンダリングは iOS 専用に閉じず、非 iOS の無音回帰も防ぐ
+
+- **ファイル**: `src/hooks/export-strategies/exportStrategyResolver.ts`, `src/hooks/useExport.ts`, `src/test/exportStrategyResolver.test.ts`
+- **問題**:
+  - `OfflineAudioContext` の事前プリレンダリングを全面有効にすると Android / PC の export 前待機が長くなり、既存より体感速度が悪化する
+  - 一方で完全に無効化すると、`MediaStreamAudioDestinationNode` の音声トラック欠落や TrackProcessor 非対応環境で mixed audio export が無音化し得る
+- **対策**:
+  - `shouldUseOfflineAudioPreRender()` は **iOS Safari**、または **非 iOS でも audio track 不在 / TrackProcessor 非対応** のときだけ true にする
+  - Android / PC で `audio track + TrackProcessor` がそろう通常ケースは高速なリアルタイム経路を優先し、前回の速度感へ戻す
+  - それでもリアルタイム音声キャプチャ結果が 0 chunk だった場合は、flush 前に `OfflineAudioContext` へフォールバックして無音ファイル化を防ぐ
+  - resolver テストで「高速経路を優先する条件」と「安全側へ倒す条件」の両方を固定し、速度と信頼性の両方を守る
+- **注意**:
+  - iOS Safari 固有の MediaRecorder / keep-alive / preview workaround は従来どおり strategy / preview policy に閉じ、非 iOS まで Safari 分岐を広げない
+  - Android / PC の export 速度だけを理由に安全側フォールバックを削る場合でも、mixed audio 実機確認なしに判断しない

--- a/src/hooks/export-strategies/exportStrategyResolver.ts
+++ b/src/hooks/export-strategies/exportStrategyResolver.ts
@@ -19,12 +19,22 @@ export function resolveExportStrategyOrder(
 export interface OfflineAudioPreRenderResolutionInput {
   hasAudioSources: boolean;
   isIosSafari: boolean;
+  hasAudioTrack: boolean;
+  canUseTrackProcessor: boolean;
 }
 
 export function shouldUseOfflineAudioPreRender(
   input: OfflineAudioPreRenderResolutionInput,
 ): boolean {
-  return input.isIosSafari && input.hasAudioSources;
+  if (!input.hasAudioSources) {
+    return false;
+  }
+
+  if (input.isIosSafari) {
+    return true;
+  }
+
+  return !input.hasAudioTrack || !input.canUseTrackProcessor;
 }
 
 export type WebCodecsAudioCaptureStrategy =

--- a/src/hooks/useExport.ts
+++ b/src/hooks/useExport.ts
@@ -969,6 +969,8 @@ export function useExport(): UseExportReturn {
         const shouldPreRenderAudio = shouldUseOfflineAudioPreRender({
           hasAudioSources: !!audioSources,
           isIosSafari,
+          hasAudioTrack: !!audioTrack,
+          canUseTrackProcessor,
         });
         if (!shouldPreRenderAudio || !audioSources) {
           return null;
@@ -1207,11 +1209,13 @@ export function useExport(): UseExportReturn {
           bitrate: audioEncoderConfig.bitrate,
         });
 
-        // === iOS Safari 限定: OfflineAudioContext による音声プリレンダリング ===
+        // === 条件付き: OfflineAudioContext による音声プリレンダリング ===
         let offlineAudioDone = false;
         const shouldPreRenderAudio = shouldUseOfflineAudioPreRender({
           hasAudioSources: !!audioSources,
           isIosSafari,
+          hasAudioTrack: !!audioTrack,
+          canUseTrackProcessor,
         });
         if (shouldPreRenderAudio && audioSources) {
           const renderedAudio = await ensurePreRenderedAudioBuffer();
@@ -1784,6 +1788,29 @@ export function useExport(): UseExportReturn {
         if (scriptProcessorSource) {
           try { scriptProcessorSource.disconnect(); } catch (e) { /* ignore */ }
           scriptProcessorSource = null;
+        }
+
+        if (!signal.aborted && audioSources && !offlineAudioDone && audioEncoderOutputChunks === 0) {
+          useLogStore.getState().warn('RENDER', 'リアルタイム音声キャプチャ結果が空のため、OfflineAudioContext へフォールバック', {
+            isIosSafari,
+            hasAudioTrack: !!audioTrack,
+            canUseTrackProcessor,
+          });
+          const renderedAudio = await ensurePreRenderedAudioBuffer();
+          if (renderedAudio && !signal.aborted) {
+            const encodedChunks = feedPreRenderedAudio(
+              renderedAudio,
+              audioEncoder,
+              signal,
+              audioSources.totalDuration,
+            );
+            offlineAudioDone = true;
+            useLogStore.getState().info('RENDER', 'OfflineAudioContext フォールバックで音声を補完', {
+              encodedChunks,
+              audioEncoderOutputChunks,
+              audioEncoderOutputBytes,
+            });
+          }
         }
 
         // ============================================================

--- a/src/test/exportStrategyResolver.test.ts
+++ b/src/test/exportStrategyResolver.test.ts
@@ -87,20 +87,46 @@ describe('resolveWebCodecsAudioCaptureStrategy', () => {
 });
 
 describe('shouldUseOfflineAudioPreRender', () => {
-  it('iOS Safari かつ音声ソースありのときだけ OfflineAudioContext を使う', () => {
+  it('iOS Safari かつ音声ソースありのときは OfflineAudioContext を使う', () => {
     expect(
       shouldUseOfflineAudioPreRender({
         hasAudioSources: true,
         isIosSafari: true,
+        hasAudioTrack: true,
+        canUseTrackProcessor: true,
       }),
     ).toBe(true);
   });
 
-  it('非iOS では音声ソースがあっても OfflineAudioContext を先行させない', () => {
+  it('非iOS でも音声トラックが無い場合は OfflineAudioContext を使って音声無音化を防ぐ', () => {
     expect(
       shouldUseOfflineAudioPreRender({
         hasAudioSources: true,
         isIosSafari: false,
+        hasAudioTrack: false,
+        canUseTrackProcessor: true,
+      }),
+    ).toBe(true);
+  });
+
+  it('非iOS でも TrackProcessor が無い場合は OfflineAudioContext を使う', () => {
+    expect(
+      shouldUseOfflineAudioPreRender({
+        hasAudioSources: true,
+        isIosSafari: false,
+        hasAudioTrack: true,
+        canUseTrackProcessor: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('非iOS で音声トラックと TrackProcessor がそろっていれば高速経路を優先する', () => {
+    expect(
+      shouldUseOfflineAudioPreRender({
+        hasAudioSources: true,
+        isIosSafari: false,
+        hasAudioTrack: true,
+        canUseTrackProcessor: true,
       }),
     ).toBe(false);
   });
@@ -110,6 +136,19 @@ describe('shouldUseOfflineAudioPreRender', () => {
       shouldUseOfflineAudioPreRender({
         hasAudioSources: false,
         isIosSafari: true,
+        hasAudioTrack: true,
+        canUseTrackProcessor: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('非iOS でも音声ソースが無ければ OfflineAudioContext を使わない', () => {
+    expect(
+      shouldUseOfflineAudioPreRender({
+        hasAudioSources: false,
+        isIosSafari: false,
+        hasAudioTrack: false,
+        canUseTrackProcessor: false,
       }),
     ).toBe(false);
   });


### PR DESCRIPTION
### Motivation
- Prevent performance regressions on Android/PC caused by unconditional `OfflineAudioContext` pre-rendering while still keeping iOS Safari fixes. 
- Avoid producing silent mixed-audio exports when `MediaStreamAudioDestinationNode` is missing or `TrackProcessor` is unsupported. 
- Ensure reliability by falling back to pre-rendering only when needed while preferring the faster real-time path on capable platforms.

### Description
- Added `hasAudioTrack` and `canUseTrackProcessor` to `OfflineAudioPreRenderResolutionInput` and to calls of `shouldUseOfflineAudioPreRender`. 
- Changed `shouldUseOfflineAudioPreRender()` to return true only when `hasAudioSources` is true and either `isIosSafari` is true or `!hasAudioTrack || !canUseTrackProcessor` is true. 
- In `useExport.ts` passed the new flags to the resolver, reused `ensurePreRenderedAudioBuffer()`, and added a post-capture safety: if real-time capture produced zero audio chunks then pre-render via `OfflineAudioContext` and feed the encoder before `flush`. 
- Expanded and updated `src/test/exportStrategyResolver.test.ts` to cover the new platform/feature combinations and adjusted wording, and updated documentation in `implementation-patterns.md` to describe the refined strategy.

### Testing
- Ran the unit tests in `src/test/exportStrategyResolver.test.ts` that exercise `shouldUseOfflineAudioPreRender` and `resolveWebCodecsAudioCaptureStrategy`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c097f68ec083259b87849d07807771)