### PR TITLE
Always pre-render export audio when audio sources exist; update resolver, hook, and tests

### DIFF
--- a/.agents/skills/turtle-video-overview/references/implementation-patterns.md
+++ b/.agents/skills/turtle-video-overview/references/implementation-patterns.md
@@ -1517,3 +1517,17 @@
   - フェード中盤まで黒クリアへ倒すと、正当なフェード途中フレームまで欠けて見えるため、alpha が十分下がった末尾だけに限定する
   - Teams 向けの muted / WebAudio 経路は既存 helper に委ね、描画不具合の修正を音声制御へ波及させない
   - 末尾 tail に入ったら「フレーム欠落時だけ黒、取得できたら描画」にすると黒↔最終フレームが交互に出て点滅しやすい。terminal window に入ったら描画自体を黒へ揃え、終端品質を優先する
+
+### 13-78. export 音声の事前プリレンダリングは iOS 専用に閉じず、非 iOS の無音回帰も防ぐ
+
+- **ファイル**: `src/hooks/export-strategies/exportStrategyResolver.ts`, `src/hooks/useExport.ts`, `src/test/exportStrategyResolver.test.ts`
+- **問題**:
+  - `OfflineAudioContext` の事前プリレンダリングを非 iOS で条件付きに戻しても、実環境では Android / PC の mixed audio export が無音化するケースを取り切れなかった
+  - そのため、速度最適化よりも「既存リリース同等に確実に音が入ること」を優先し、音声付き export は platform を問わず事前プリレンダリングを維持する必要がある
+- **対策**:
+  - `shouldUseOfflineAudioPreRender()` は **音声ソースが存在するなら true** を返し、iOS / Android / PC を問わず export 前にタイムライン音声を確定させる
+  - pre-rendered 音声を feed できた export では `resolveWebCodecsAudioCaptureStrategy()` が `pre-rendered` を返し、追加のリアルタイム音声キャプチャには進まない
+  - resolver テストでも「音声ソースありなら pre-render、無ければ不要」を固定し、再発を防ぐ
+- **注意**:
+  - iOS Safari 固有の MediaRecorder / keep-alive / preview workaround は従来どおり strategy / preview policy に閉じ、非 iOS まで Safari 分岐を広げない
+  - それでも export に時間がかかるのは、現行実装では **音声プリレンダとは別に動画フレーム生成が再生ループ同期で進む** ためであり、ここを短縮するには video export パイプライン自体の非リアルタイム化が別途必要になる

--- a/src/hooks/export-strategies/exportStrategyResolver.ts
+++ b/src/hooks/export-strategies/exportStrategyResolver.ts
@@ -24,7 +24,8 @@ export interface OfflineAudioPreRenderResolutionInput {
 export function shouldUseOfflineAudioPreRender(
   input: OfflineAudioPreRenderResolutionInput,
 ): boolean {
-  return input.isIosSafari && input.hasAudioSources;
+  const { hasAudioSources } = input;
+  return hasAudioSources;
 }
 
 export type WebCodecsAudioCaptureStrategy =

--- a/src/hooks/useExport.ts
+++ b/src/hooks/useExport.ts
@@ -1207,7 +1207,7 @@ export function useExport(): UseExportReturn {
           bitrate: audioEncoderConfig.bitrate,
         });
 
-        // === iOS Safari 限定: OfflineAudioContext による音声プリレンダリング ===
+        // === 共通: OfflineAudioContext による音声プリレンダリング ===
         let offlineAudioDone = false;
         const shouldPreRenderAudio = shouldUseOfflineAudioPreRender({
           hasAudioSources: !!audioSources,

--- a/src/test/exportStrategyResolver.test.ts
+++ b/src/test/exportStrategyResolver.test.ts
@@ -87,7 +87,7 @@ describe('resolveWebCodecsAudioCaptureStrategy', () => {
 });
 
 describe('shouldUseOfflineAudioPreRender', () => {
-  it('iOS Safari かつ音声ソースありのときだけ OfflineAudioContext を使う', () => {
+  it('iOS Safari かつ音声ソースありのときは OfflineAudioContext を使う', () => {
     expect(
       shouldUseOfflineAudioPreRender({
         hasAudioSources: true,
@@ -96,13 +96,13 @@ describe('shouldUseOfflineAudioPreRender', () => {
     ).toBe(true);
   });
 
-  it('非iOS では音声ソースがあっても OfflineAudioContext を先行させない', () => {
+  it('非iOS でも音声ソースがあれば OfflineAudioContext を使う', () => {
     expect(
       shouldUseOfflineAudioPreRender({
         hasAudioSources: true,
         isIosSafari: false,
       }),
-    ).toBe(false);
+    ).toBe(true);
   });
 
   it('iOS Safari でも音声ソースが無ければ OfflineAudioContext を使わない', () => {
@@ -110,6 +110,15 @@ describe('shouldUseOfflineAudioPreRender', () => {
       shouldUseOfflineAudioPreRender({
         hasAudioSources: false,
         isIosSafari: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('非iOS でも音声ソースが無ければ OfflineAudioContext を使わない', () => {
+    expect(
+      shouldUseOfflineAudioPreRender({
+        hasAudioSources: false,
+        isIosSafari: false,
       }),
     ).toBe(false);
   });


### PR DESCRIPTION
### Motivation
- Prevent silent/muted audio in exported files by ensuring audio is deterministically prepared before export rather than gating pre-rendering by iOS only.
- Centralize platform decision into the export strategy resolver so export behavior is explicit and easier to test. 

### Description
- Change `shouldUseOfflineAudioPreRender()` to return true whenever `hasAudioSources` is true, regardless of `isIosSafari`, and update related documentation in `implementation-patterns.md`.
- Update `useExport.ts` to treat OfflineAudioContext pre-rendering as a common step and to rely solely on the resolver result when deciding to feed pre-rendered audio. 
- Adjust unit tests in `src/test/exportStrategyResolver.test.ts` to reflect the new resolver semantics and add a test for the non-iOS empty-audio case. 
- Leave `resolveWebCodecsAudioCaptureStrategy()` behavior unchanged except that callers will now see `offlineAudioDone` set when pre-rendering is used.

### Testing
- Ran the resolver unit tests in `src/test/exportStrategyResolver.test.ts` (via the project's test runner) and all assertions passed. 
- Verified TypeScript compilation for the modified modules succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c097f68ec083259b87849d07807771)