### PR TITLE
非iOSエクスポート: OfflineAudioContext フォールバックのウォームアップを先行（開始待ちを回避）

### DIFF
--- a/.agents/skills/turtle-video-overview/references/implementation-patterns.md
+++ b/.agents/skills/turtle-video-overview/references/implementation-patterns.md
@@ -62,6 +62,20 @@
   - `blur` だけで即 pause するとファイルピッカーや保存ダイアログでも再生が止まりやすいので、blur では「再同期予約」までに留める
   - 可視復帰時の `load()` は停止中だけに限定し、再生中は `resync + renderFrame` で復旧させる
 
+### 0-5. 非 iOS export の OfflineAudioContext フォールバックは待機せず warmup だけ先行する
+
+- **ファイル**: `src/hooks/useExport.ts`, `src/hooks/export-strategies/exportStrategyResolver.ts`, `src/test/exportStrategyResolver.test.ts`
+- **背景**:
+  - 非 iOS で export 開始前に `OfflineAudioContext` を待つと、PC / Android の体感速度が落ちやすい
+  - 一方で、リアルタイム音声キャプチャが 0 chunk になったケースでは、終了後に初めてオフライン描画を始めると待ち時間が長く、失敗時の復旧も遅れる
+- **実装指針**:
+  - iOS Safari は従来どおり事前プリレンダリングを export 開始条件として扱う
+  - 非 iOS は `shouldWarmupOfflineAudioFallback()` で warmup 可否だけ判定し、export 本体は待たずに開始する
+  - warmup した `OfflineAudioContext` 結果は 0 chunk フォールバック時に再利用し、無音回帰時だけ補完へ使う
+- **注意点**:
+  - 非 iOS の warmup は「準備開始」であって「開始待ち」ではない。`onAudioPreRenderComplete` を遅らせない
+  - platform 分岐は resolver に集約し、`useExport.ts` に iOS/非 iOS の if を散らさない
+
 ## 1. スクロール/スワイプ誤操作防止
 
 ### 1-1. モーダル表示時のボディスクロールロック

--- a/src/hooks/export-strategies/exportStrategyResolver.ts
+++ b/src/hooks/export-strategies/exportStrategyResolver.ts
@@ -31,6 +31,16 @@ export function shouldUseOfflineAudioPreRender(
   return input.isIosSafari;
 }
 
+export function shouldWarmupOfflineAudioFallback(
+  input: OfflineAudioPreRenderResolutionInput
+): boolean {
+  if (!input.hasAudioSources) {
+    return false;
+  }
+
+  return !input.isIosSafari;
+}
+
 export type WebCodecsAudioCaptureStrategy = 'pre-rendered' | 'track-processor' | 'script-processor';
 
 export interface WebCodecsAudioCaptureResolutionInput {

--- a/src/hooks/useExport.ts
+++ b/src/hooks/useExport.ts
@@ -13,6 +13,7 @@ import {
   resolveExportStrategyOrder,
   shouldUseOfflineAudioPreRender,
   resolveWebCodecsAudioCaptureStrategy,
+  shouldWarmupOfflineAudioFallback,
 } from './export-strategies/exportStrategyResolver';
 import { runIosSafariMediaRecorderStrategy } from './export-strategies/iosSafariMediaRecorder';
 import type {
@@ -962,18 +963,25 @@ export function useExport(): UseExportReturn {
       let canvasFramePumpTimer: ReturnType<typeof setInterval> | null = null;
       let preRenderedAudioBuffer: AudioBuffer | null = null;
       let preRenderedAudioPrepared = false;
+      let preRenderedAudioPromise: Promise<AudioBuffer | null> | null = null;
+      const shouldPrepareOfflineAudioBuffer = shouldUseOfflineAudioPreRender({
+        hasAudioSources: !!audioSources,
+        isIosSafari,
+      }) || shouldWarmupOfflineAudioFallback({
+        hasAudioSources: !!audioSources,
+        isIosSafari,
+      });
 
-      const ensurePreRenderedAudioBuffer = async (): Promise<AudioBuffer | null> => {
+      const ensurePreRenderedAudioBuffer = async (reason: 'required' | 'warmup' = 'required'): Promise<AudioBuffer | null> => {
+        if (preRenderedAudioPromise) {
+          return preRenderedAudioPromise;
+        }
         if (preRenderedAudioPrepared) {
           return preRenderedAudioBuffer;
         }
         preRenderedAudioPrepared = true;
 
-        const shouldPreRenderAudio = shouldUseOfflineAudioPreRender({
-          hasAudioSources: !!audioSources,
-          isIosSafari,
-        });
-        if (!shouldPreRenderAudio || !audioSources) {
+        if (!shouldPrepareOfflineAudioBuffer || !audioSources) {
           return null;
         }
 
@@ -981,26 +989,31 @@ export function useExport(): UseExportReturn {
           totalDuration: audioSources.totalDuration,
           sampleRate: audioContext.sampleRate,
           isIosSafari,
+          reason,
         });
 
-        try {
-          const renderedAudio = await offlineRenderAudio(
-            audioSources,
-            audioContext as AudioContext,
-            audioContext.sampleRate,
-            signal,
-          );
-          if (renderedAudio && !signal.aborted) {
-            updatePreparationStep(audioSources, 4);
-            preRenderedAudioBuffer = renderedAudio;
+        preRenderedAudioPromise = (async () => {
+          try {
+            const renderedAudio = await offlineRenderAudio(
+              audioSources,
+              audioContext as AudioContext,
+              audioContext.sampleRate,
+              signal,
+            );
+            if (renderedAudio && !signal.aborted) {
+              updatePreparationStep(audioSources, 4);
+              preRenderedAudioBuffer = renderedAudio;
+            }
+          } catch (e) {
+            useLogStore.getState().warn('RENDER', 'OfflineAudioContext失敗、通常経路へフォールバック', {
+              error: e instanceof Error ? e.message : String(e),
+              reason,
+            });
           }
-        } catch (e) {
-          useLogStore.getState().warn('RENDER', 'OfflineAudioContext失敗、通常経路へフォールバック', {
-            error: e instanceof Error ? e.message : String(e),
-          });
-        }
+          return preRenderedAudioBuffer;
+        })();
 
-        return preRenderedAudioBuffer;
+        return preRenderedAudioPromise;
       };
 
       try {
@@ -1014,7 +1027,15 @@ export function useExport(): UseExportReturn {
           isIosSafari,
           supportsTrackProcessor: canUseTrackProcessor,
           supportsMp4MediaRecorder: !!supportedMediaRecorderProfile,
+          warmupOfflineAudioFallback: shouldWarmupOfflineAudioFallback({
+            hasAudioSources: !!audioSources,
+            isIosSafari,
+          }),
         });
+
+        if (shouldWarmupOfflineAudioFallback({ hasAudioSources: !!audioSources, isIosSafari })) {
+          void ensurePreRenderedAudioBuffer('warmup');
+        }
 
         if (isIosSafari) {
           useLogStore.getState().info('RENDER', 'iOS Safari export route', {
@@ -1028,7 +1049,7 @@ export function useExport(): UseExportReturn {
 
         if (strategyOrder.includes('ios-safari-mediarecorder')) {
           let preRenderedAudio: PreRenderedRecorderAudioSource | null = null;
-          const renderedAudioForMediaRecorder = await ensurePreRenderedAudioBuffer();
+          const renderedAudioForMediaRecorder = await ensurePreRenderedAudioBuffer('required');
           if (renderedAudioForMediaRecorder && !signal.aborted) {
             preRenderedAudio = createPreRenderedRecorderAudioSource(
               renderedAudioForMediaRecorder,
@@ -1217,7 +1238,7 @@ export function useExport(): UseExportReturn {
           isIosSafari,
         });
         if (shouldPreRenderAudio && audioSources) {
-          const renderedAudio = await ensurePreRenderedAudioBuffer();
+          const renderedAudio = await ensurePreRenderedAudioBuffer('required');
           if (renderedAudio && !signal.aborted) {
             useLogStore.getState().info('RENDER', '[DIAG-4] feed開始前 AudioEncoder状態', {
               state: audioEncoder.state,
@@ -1776,7 +1797,7 @@ export function useExport(): UseExportReturn {
         // 音声プリレンダリング完了を通知 — エクスポート用の再生ループを開始させる
         // iOS Safari では extractAudioViaVideoElement にリアルタイムがかかるため、
         // このコールバックのタイミングが重要。
-        // PC/Android では offlineRenderAudio が高速なため即座に呼ばれる。
+        // 非iOS は export 開始待ちを増やさず、必要なら裏で warmup を進める。
         useLogStore.getState().info('RENDER', '[DIAG-READY] 音声準備完了、再生ループ開始通知');
         audioSources?.onAudioPreRenderComplete?.();
 
@@ -1802,7 +1823,7 @@ export function useExport(): UseExportReturn {
             audioTrackReadyState: audioTrack?.readyState ?? 'none',
             canUseTrackProcessor,
           });
-          const renderedAudio = await ensurePreRenderedAudioBuffer();
+          const renderedAudio = await ensurePreRenderedAudioBuffer('required');
           if (renderedAudio && !signal.aborted) {
             const encodedChunks = feedPreRenderedAudio(
               renderedAudio,

--- a/src/test/exportStrategyResolver.test.ts
+++ b/src/test/exportStrategyResolver.test.ts
@@ -3,6 +3,7 @@ import {
   resolveExportStrategyOrder,
   resolveWebCodecsAudioCaptureStrategy,
   shouldUseOfflineAudioPreRender,
+  shouldWarmupOfflineAudioFallback,
 } from '../hooks/export-strategies/exportStrategyResolver';
 
 describe('resolveExportStrategyOrder', () => {
@@ -154,6 +155,35 @@ describe('shouldUseOfflineAudioPreRender', () => {
   it('非iOS でも音声ソースが無ければ OfflineAudioContext を使わない', () => {
     expect(
       shouldUseOfflineAudioPreRender({
+        hasAudioSources: false,
+        isIosSafari: false,
+      })
+    ).toBe(false);
+  });
+});
+
+describe('shouldWarmupOfflineAudioFallback', () => {
+  it('非iOS かつ音声ソースありのときは裏でフォールバック準備を始める', () => {
+    expect(
+      shouldWarmupOfflineAudioFallback({
+        hasAudioSources: true,
+        isIosSafari: false,
+      })
+    ).toBe(true);
+  });
+
+  it('iOS Safari では warmup ではなく事前プリレンダリング側で扱う', () => {
+    expect(
+      shouldWarmupOfflineAudioFallback({
+        hasAudioSources: true,
+        isIosSafari: true,
+      })
+    ).toBe(false);
+  });
+
+  it('音声ソースが無ければ warmup しない', () => {
+    expect(
+      shouldWarmupOfflineAudioFallback({
         hasAudioSources: false,
         isIosSafari: false,
       })


### PR DESCRIPTION
### Motivation
- 非iOS（PC/Android）でエクスポート開始前に `OfflineAudioContext` を待つと体感速度が落ちる一方、リアルタイム音声キャプチャが 0 チャンクだった場合の復旧が遅くなる問題を解消するため。 
- iOS Safari 向けの既存の事前プリレンダリング経路は維持しつつ、非iOSでは開始待ちを増やさずに補完用の準備を裏で進めたいという狙い。 
- プラットフォーム責務を `exportStrategyResolver` に集約して分岐の明確化とテスト固定化を図るため。 

### Description
- `src/hooks/export-strategies/exportStrategyResolver.ts` に `shouldWarmupOfflineAudioFallback()` を追加して、非iOSかつ音声ソースありのときにウォームアップを許可する判定を実装した。 
- `src/hooks/useExport.ts` を変更し、`OfflineAudioContext` のプリレンダリング結果を共有する `preRenderedAudioPromise` を導入して `warmup` と `required`（iOSの必須プリレンダ）両経路から再利用できるようにした。 
- 非iOSではエクスポート開始時に裏で `ensurePreRenderedAudioBuffer('warmup')` を起動して準備を進めつつ、`onAudioPreRenderComplete` は待たず即通知する挙動とし、リアルタイム音声が 0 チャンクだった場合のみウォームアップ済みバッファを補完に使うようにした。 
- 関連テスト `src/test/exportStrategyResolver.test.ts` を更新して新判定を追加し、実装パターン説明を `.agents/skills/turtle-video-overview/references/implementation-patterns.md` に追記した。 

### Testing
- 単体テスト: `npm run test:run -- src/test/exportStrategyResolver.test.ts` を実行しパスした（該当テスト成功）。 
- 全テスト: `npm run test:run` を実行し、リポジトリ内のテストスイート全体が成功（すべてのテストが通過）した。 
- ビルド: `npm run build` を実行し、TypeScript コンパイルと Vite ビルドが成功した（ビルド完了、チャンク警告は出力）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0b8c140148325b370eadb74756892)