### PR TITLE
Stabilize non-iOS export frame pacing (deterministic frame counter)

### DIFF
--- a/.agents/skills/turtle-video-overview/references/implementation-patterns.md
+++ b/.agents/skills/turtle-video-overview/references/implementation-patterns.md
@@ -76,6 +76,20 @@
   - iOS Safari の MediaRecorder 経路はそのまま維持し、非 iOS の滑らかさ対策を iOS 側へ波及させない
   - 非 iOS の時刻スナップは export ループだけに閉じ、通常 preview の再生体感は変えない
 
+### 0-6. 非 iOS export の時間進行は壁時計ではなく決定的なフレームカウンタで進める
+
+- **ファイル**: `src/components/TurtleVideo.tsx`, `src/utils/exportFrameTiming.ts`, `src/test/exportFrameTiming.test.ts`
+- **背景**:
+  - `Date.now()` ベースで `elapsed` を切り下げるだけでは、rAF の遅延やメインスレッド負荷が大きいと描画時刻自体が飛び、30fps 出力でも motion が所々で引っかかったように見えることがある
+  - 非 iOS export は OfflineAudioContext で音声を先行確定できるため、映像側もリアルタイム追従より「1 フレームずつ確実に進める」方が安定しやすい
+- **実装指針**:
+  - 非 iOS export では `fromTime + renderedFrameCount / FPS` を現在時刻として使い、壁時計ではなくフレームカウンタから `renderFrame()` の描画時刻を決める
+  - export 開始時と `onAudioPreRenderComplete` 後にフレームカウンタを必ずリセットし、準備時間や一時停止の遅れがタイムライン進行へ混ざらないようにする
+  - フレームカウンタは `stopAll()` でもクリアし、次回 preview / export セッションへ持ち越さない
+- **注意点**:
+  - この決定的ステップ進行は非 iOS export 専用で、iOS Safari の MediaRecorder 経路や通常 preview の `Date.now()` 依存ループは変更しない
+  - 進行基準を frame index に寄せても、最終停止判定と音声フォールバックは既存ロジックを維持して AV 尺合わせを崩さない
+
 ## 1. スクロール/スワイプ誤操作防止
 
 ### 1-1. モーダル表示時のボディスクロールロック

--- a/src/components/TurtleVideo.tsx
+++ b/src/components/TurtleVideo.tsx
@@ -33,6 +33,7 @@ import { openFilesWithPicker } from '../utils/platform';
 import { findActiveTimelineItem, collectPlaybackBlockingVideos } from '../utils/playbackTimeline';
 import { getPlatformCapabilities } from '../utils/platform';
 import { resolveIosSafariSingleMixedAudio } from '../utils/iosSafariAudio';
+import { getDeterministicExportFrameTimeSec } from '../utils/exportFrameTiming';
 import {
   getFutureVideoAudioProbeTimes,
   getPreviewAudioOutputMode,
@@ -289,6 +290,8 @@ const TurtleVideo: React.FC = () => {
   const audioRoutingModeRef = useRef<'preview' | 'export'>('preview');
   const reqIdRef = useRef<number | null>(null);
   const startTimeRef = useRef(0);
+  const exportFrameBaseTimeRef = useRef(0);
+  const exportRenderedFrameCountRef = useRef(0);
   const hiddenStartedAtRef = useRef<number | null>(null);
   const needsResyncAfterVisibilityRef = useRef(false);
   const audioResumeWaitFramesRef = useRef(0);
@@ -3330,6 +3333,8 @@ const TurtleVideo: React.FC = () => {
     isPlayingRef.current = false;
     audioResumeWaitFramesRef.current = 0;
     activeVideoIdRef.current = null;
+    exportFrameBaseTimeRef.current = 0;
+    exportRenderedFrameCountRef.current = 0;
     setLoading(false);
 
     // シーク関連の状態をリセット
@@ -3563,11 +3568,14 @@ const TurtleVideo: React.FC = () => {
       }
 
       const now = Date.now();
-      const elapsed = (now - startTimeRef.current) / 1000;
-      const exportFrameDurationSec = 1 / FPS;
-      const timelineElapsed = isExportMode && !platformCapabilities.isIosSafari
-        ? Math.floor(elapsed / exportFrameDurationSec) * exportFrameDurationSec
-        : elapsed;
+      const isDeterministicNonIosExport = isExportMode && !platformCapabilities.isIosSafari;
+      const timelineElapsed = isDeterministicNonIosExport
+        ? getDeterministicExportFrameTimeSec({
+          baseTimeSec: exportFrameBaseTimeRef.current,
+          renderedFrameCount: exportRenderedFrameCountRef.current,
+          fps: FPS,
+        })
+        : (now - startTimeRef.current) / 1000;
       const clampedElapsed = Math.min(timelineElapsed, totalDurationRef.current);
 
       if (clampedElapsed >= totalDurationRef.current) {
@@ -3657,6 +3665,9 @@ const TurtleVideo: React.FC = () => {
       setCurrentTime(clampedElapsed);
       currentTimeRef.current = clampedElapsed;
       renderFrame(clampedElapsed, true, isExportMode);
+      if (isDeterministicNonIosExport) {
+        exportRenderedFrameCountRef.current += 1;
+      }
       reqIdRef.current = requestAnimationFrame(() => loop(isExportMode, myLoopId));
     },
     [stopAll, pause, setCurrentTime, renderFrame, logDebug, logWarn, platformCapabilities.isIosSafari]
@@ -3894,6 +3905,8 @@ const TurtleVideo: React.FC = () => {
       }
 
       if (isExportMode) {
+        exportFrameBaseTimeRef.current = fromTime;
+        exportRenderedFrameCountRef.current = 0;
         setCurrentTime(fromTime);
         currentTimeRef.current = fromTime;
         mediaItemsRef.current.forEach((item) => {
@@ -4206,6 +4219,8 @@ const TurtleVideo: React.FC = () => {
             // 事前処理に要した時間が終了判定に混ざらないようにする。
             onAudioPreRenderComplete: () => {
               startTimeRef.current = Date.now() - fromTime * 1000;
+              exportFrameBaseTimeRef.current = fromTime;
+              exportRenderedFrameCountRef.current = 0;
               loop(isExportMode, myLoopId);
             },
           }

--- a/src/test/exportFrameTiming.test.ts
+++ b/src/test/exportFrameTiming.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { getDeterministicExportFrameTimeSec } from '../utils/exportFrameTiming';
+
+describe('getDeterministicExportFrameTimeSec', () => {
+  it('非 iOS export はフレーム数ベースで等間隔に進める', () => {
+    expect(
+      getDeterministicExportFrameTimeSec({
+        baseTimeSec: 0,
+        renderedFrameCount: 0,
+        fps: 30,
+      }),
+    ).toBe(0);
+
+    expect(
+      getDeterministicExportFrameTimeSec({
+        baseTimeSec: 0,
+        renderedFrameCount: 1,
+        fps: 30,
+      }),
+    ).toBeCloseTo(1 / 30);
+
+    expect(
+      getDeterministicExportFrameTimeSec({
+        baseTimeSec: 0,
+        renderedFrameCount: 15,
+        fps: 30,
+      }),
+    ).toBeCloseTo(0.5);
+  });
+
+  it('開始位置が 0 秒以外でもその位置を起点に進める', () => {
+    expect(
+      getDeterministicExportFrameTimeSec({
+        baseTimeSec: 1.25,
+        renderedFrameCount: 3,
+        fps: 30,
+      }),
+    ).toBeCloseTo(1.35);
+  });
+
+  it('不正な入力でも安全な値へ正規化する', () => {
+    expect(
+      getDeterministicExportFrameTimeSec({
+        baseTimeSec: -5,
+        renderedFrameCount: -2,
+        fps: 0,
+      }),
+    ).toBe(0);
+  });
+});

--- a/src/utils/exportFrameTiming.ts
+++ b/src/utils/exportFrameTiming.ts
@@ -1,0 +1,22 @@
+export interface DeterministicExportFrameTimeInput {
+  baseTimeSec: number;
+  renderedFrameCount: number;
+  fps: number;
+}
+
+/**
+ * 非 iOS export の時間進行を壁時計ではなくフレーム数ベースで決める。
+ * これにより rAF の揺れがそのままタイムラインの揺れにならず、
+ * CFR 30fps のエンコード時刻と描画時刻を一致させやすくする。
+ */
+export function getDeterministicExportFrameTimeSec(
+  input: DeterministicExportFrameTimeInput,
+): number {
+  const safeBaseTimeSec = Number.isFinite(input.baseTimeSec) ? Math.max(0, input.baseTimeSec) : 0;
+  const safeRenderedFrameCount = Number.isFinite(input.renderedFrameCount)
+    ? Math.max(0, Math.floor(input.renderedFrameCount))
+    : 0;
+  const safeFps = Number.isFinite(input.fps) && input.fps > 0 ? input.fps : 30;
+
+  return safeBaseTimeSec + safeRenderedFrameCount / safeFps;
+}


### PR DESCRIPTION
### Motivation
- Android/PC のエクスポートで 30 FPS でも所々カクつく報告があり、`Date.now()` ベースの壁時計依存だと rAF やメインスレッド負荷の揺れが映像時刻へ反映されやすかったため安定化が必要と判断した。 
- 非 iOS 環境では音声を `OfflineAudioContext` で先行プリレンダリングする方針を維持しつつ、映像側は「決定的に 1 フレームずつ進める」方式にして体感の滑らかさを改善する狙いです。

### Description
- 追加で純粋関数 `getDeterministicExportFrameTimeSec` を `src/utils/exportFrameTiming.ts` に実装し、`baseTime + renderedFrameCount / FPS` で非 iOS export の時刻を決定するようにした。 
- `src/components/TurtleVideo.tsx` に `exportFrameBaseTimeRef` と `exportRenderedFrameCountRef` を導入し、非 iOS のエクスポートループで壁時計ではなく上記ヘルパーを使って `renderFrame()` の描画時刻を決定するように変更した。 
- export の開始 (`startEngine`)、`onAudioPreRenderComplete` 完了時、`stopAll()` 実行時にフレームカウンタをリセットする処理を追加して、準備時間や停止状態が次セッションに持ち越されないようにした。 
- 実装パターン文書 `.agents/skills/turtle-video-overview/references/implementation-patterns.md` に「非 iOS export はフレームカウンタで進める」方針を追記した。 
- ユニットテスト `src/test/exportFrameTiming.test.ts` を追加し、純粋関数の期待挙動を固定化した。 

### Testing
- 単体／関連テスト: `npm run test:run -- src/test/exportFrameTiming.test.ts src/test/exportStrategyResolver.test.ts src/test/useExport.test.ts` はすべて成功（該当テストファイルは合格）。
- 全体テスト: `npm run test:run` を実行し、レポート上の全テストが通過しました（全体: 229 tests passed in CI run shown）。
- ビルド: `npm run build` を実行し、TypeScript コンパイルと Vite ビルドともに成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0d9706b648325ba51ae3209c4bd04)