### PR TITLE
Align export audio/video duration to CFR frame grid to prevent Teams playback slowdown

### DIFF
--- a/.agents/skills/turtle-video-overview/references/implementation-patterns.md
+++ b/.agents/skills/turtle-video-overview/references/implementation-patterns.md
@@ -1587,3 +1587,17 @@
 - **注意**:
   - Android / PC の速度最適化は「track が live な通常ケース」でのみ TrackProcessor を使う
   - iOS 側の事前プリレンダリング条件にはこの判定を混ぜず、platform 条件を分離して保つ
+
+### 13-80. export 尺はタイムライン値ではなく CFR フレーム境界へ切り上げて音声終端も同じ長さへ合わせる
+
+- **ファイル**: `src/hooks/useExport.ts`, `src/utils/exportTimeline.ts`, `src/test/exportTimeline.test.ts`
+- **問題**:
+  - WebCodecs export は 30fps の CFR で映像フレーム数を離散化するため、`totalDuration` がフレーム境界に乗らない案件では `frameCount / FPS` と音声長が数ms〜十数msずれることがある
+  - この差分が小さくても、Teams 側が「音声と動画にズレあり」と見なして再パッケージ時に補正し、わずかな遅延やスロー再生感として再発する場合がある
+- **対策**:
+  - `alignExportDurationToFrameGrid()` で export 尺を `ceil(totalDuration * FPS) / FPS` へ切り上げ、映像フレーム数とコンテナ上の最終動画時刻を先に確定する
+  - `useExport.ts` では `expectedVideoFrames`、`maxAudioTimestampUs`、`OfflineAudioContext` のプリレンダ長、`feedPreRenderedAudio()` の上限長に同じ aligned duration を共有し、動画・音声の終端を必ず一致させる
+  - 診断ログにも raw duration と aligned duration を残し、境界ズレの再発を追跡できるようにする
+- **注意**:
+  - 端数を切り捨てると末尾コンテンツを欠く可能性があるため、必ず切り上げる
+  - 修正は export 専用に閉じ、preview 再生の時間進行や iOS Safari MediaRecorder 分岐の責務は変えない

--- a/src/hooks/useExport.ts
+++ b/src/hooks/useExport.ts
@@ -9,6 +9,7 @@ import * as Mp4Muxer from 'mp4-muxer';
 import type { AudioTrack, NarrationClip } from '../types';
 import { useLogStore } from '../stores/logStore';
 import { getPlatformCapabilities } from '../utils/platform';
+import { alignExportDurationToFrameGrid } from '../utils/exportTimeline';
 import {
   resolveExportStrategyOrder,
   shouldUseOfflineAudioPreRender,
@@ -891,6 +892,10 @@ export function useExport(): UseExportReturn {
       } = platformCapabilities;
 
       // ============================================================
+      const exportTimelineAlignment = audioSources
+        ? alignExportDurationToFrameGrid(audioSources.totalDuration, FPS)
+        : null;
+
       // [DIAG-1] プラットフォーム検出・入力情報の診断ログ
       // ============================================================
       useLogStore.getState().info('RENDER', '[DIAG-1] プラットフォーム・入力診断', {
@@ -912,6 +917,10 @@ export function useExport(): UseExportReturn {
           hasBgm: !!audioSources.bgm,
           narrationCount: audioSources.narrations.length,
           totalDuration: Math.round(audioSources.totalDuration * 100) / 100,
+          alignedDurationSec: exportTimelineAlignment
+            ? Math.round(exportTimelineAlignment.alignedDurationSec * 1000) / 1000
+            : null,
+          alignedFrameCount: exportTimelineAlignment?.frameCount ?? null,
         } : null,
       });
 
@@ -941,14 +950,12 @@ export function useExport(): UseExportReturn {
       const controller = new AbortController();
       abortControllerRef.current = controller;
       const { signal } = controller;
-      const maxAudioTimestampUs =
-        audioSources && Number.isFinite(audioSources.totalDuration)
-          ? Math.max(0, Math.round(audioSources.totalDuration * 1e6))
-          : Number.POSITIVE_INFINITY;
-      const expectedVideoFrames =
-        audioSources && Number.isFinite(audioSources.totalDuration)
-          ? Math.max(1, Math.round(audioSources.totalDuration * FPS))
-          : null;
+      const maxAudioTimestampUs = exportTimelineAlignment
+        ? exportTimelineAlignment.alignedDurationUs
+        : Number.POSITIVE_INFINITY;
+      const expectedVideoFrames = exportTimelineAlignment
+        ? Math.max(1, exportTimelineAlignment.frameCount)
+        : null;
       const getPlaybackTimeSec = (): number | null => {
         if (!audioSources?.getPlaybackTimeSec) return null;
         const raw = audioSources.getPlaybackTimeSec();
@@ -981,8 +988,11 @@ export function useExport(): UseExportReturn {
           return null;
         }
 
+        const preRenderedAudioDurationSec = exportTimelineAlignment?.alignedDurationSec ?? audioSources.totalDuration;
+
         useLogStore.getState().info('RENDER', '[DIAG-3] OfflineAudioContext パス開始', {
           totalDuration: audioSources.totalDuration,
+          alignedDurationSec: preRenderedAudioDurationSec,
           sampleRate: audioContext.sampleRate,
           isIosSafari,
           reason,
@@ -991,7 +1001,10 @@ export function useExport(): UseExportReturn {
         preRenderedAudioPromise = (async () => {
           try {
             const renderedAudio = await offlineRenderAudio(
-              audioSources,
+              {
+                ...audioSources,
+                totalDuration: preRenderedAudioDurationSec,
+              },
               audioContext as AudioContext,
               audioContext.sampleRate,
               signal,
@@ -1238,7 +1251,7 @@ export function useExport(): UseExportReturn {
               renderedAudio,
               audioEncoder,
               signal,
-              audioSources.totalDuration,
+              exportTimelineAlignment?.alignedDurationSec ?? audioSources.totalDuration,
             );
             useLogStore.getState().info('RENDER', '[DIAG-5] feed完了後 AudioEncoder状態', {
               state: audioEncoder.state,
@@ -1817,7 +1830,7 @@ export function useExport(): UseExportReturn {
               renderedAudio,
               audioEncoder,
               signal,
-              audioSources.totalDuration,
+              exportTimelineAlignment?.alignedDurationSec ?? audioSources.totalDuration,
             );
             offlineAudioDone = true;
             useLogStore.getState().info('RENDER', 'OfflineAudioContext フォールバックで音声を補完', {

--- a/src/test/exportTimeline.test.ts
+++ b/src/test/exportTimeline.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { alignExportDurationToFrameGrid } from '../utils/exportTimeline';
+
+describe('alignExportDurationToFrameGrid', () => {
+  it('フレーム境界ちょうどの尺はそのまま維持する', () => {
+    expect(alignExportDurationToFrameGrid(2, 30)).toEqual({
+      rawDurationSec: 2,
+      frameCount: 60,
+      alignedDurationSec: 2,
+      alignedDurationUs: 2_000_000,
+    });
+  });
+
+  it('フレーム境界に乗らない尺は切り上げて動画と音声の終端を一致させる', () => {
+    const aligned = alignExportDurationToFrameGrid(10.01, 30);
+
+    expect(aligned.rawDurationSec).toBe(10.01);
+    expect(aligned.frameCount).toBe(301);
+    expect(aligned.alignedDurationSec).toBeCloseTo(301 / 30, 10);
+    expect(aligned.alignedDurationUs).toBe(Math.round((301 / 30) * 1e6));
+  });
+
+  it('浮動小数の誤差で余計な1フレームを増やさない', () => {
+    const aligned = alignExportDurationToFrameGrid(60 / 30 + 1e-12, 30);
+
+    expect(aligned.frameCount).toBe(60);
+    expect(aligned.alignedDurationSec).toBe(2);
+  });
+
+  it('不正な入力はゼロ尺として扱う', () => {
+    expect(alignExportDurationToFrameGrid(-1, 30).frameCount).toBe(0);
+    expect(alignExportDurationToFrameGrid(10, 0).alignedDurationSec).toBe(0);
+  });
+});

--- a/src/utils/exportTimeline.ts
+++ b/src/utils/exportTimeline.ts
@@ -1,0 +1,36 @@
+export interface ExportTimelineAlignment {
+  rawDurationSec: number;
+  frameCount: number;
+  alignedDurationSec: number;
+  alignedDurationUs: number;
+}
+
+const DURATION_EPSILON = 1e-9;
+
+export function alignExportDurationToFrameGrid(
+  totalDurationSec: number,
+  fps: number,
+): ExportTimelineAlignment {
+  const safeDurationSec = Number.isFinite(totalDurationSec) && totalDurationSec > 0 ? totalDurationSec : 0;
+  const safeFps = Number.isFinite(fps) && fps > 0 ? fps : 0;
+
+  if (safeDurationSec <= 0 || safeFps <= 0) {
+    return {
+      rawDurationSec: safeDurationSec,
+      frameCount: 0,
+      alignedDurationSec: 0,
+      alignedDurationUs: 0,
+    };
+  }
+
+  const rawFrameCount = safeDurationSec * safeFps;
+  const frameCount = Math.max(1, Math.ceil(rawFrameCount - DURATION_EPSILON));
+  const alignedDurationSec = frameCount / safeFps;
+
+  return {
+    rawDurationSec: safeDurationSec,
+    frameCount,
+    alignedDurationSec,
+    alignedDurationUs: Math.max(0, Math.round(alignedDurationSec * 1e6)),
+  };
+}


### PR DESCRIPTION
### Motivation
- Teams playback could appear slightly slow because exported audio and video durations differed by a small amount, prompting Teams to repackage/re-encode and introduce perceived slowdown.
- The fix must ensure exported video frame count (CFR) and audio final timestamp share the same canonical length so downstream players (like Teams) do not adjust timing. 
- Keep the change isolated to export logic to avoid impacting preview/playback and iOS MediaRecorder strategy code paths.

### Description
- Add `alignExportDurationToFrameGrid()` in `src/utils/exportTimeline.ts` to compute an aligned export duration by rounding up to the CFR frame grid (`ceil(totalDuration * FPS) / FPS`) while guarding against floating-point epsilon.
- Use the aligned duration inside `src/hooks/useExport.ts` to derive `expectedVideoFrames`, `maxAudioTimestampUs`, `OfflineAudioContext` pre-render length, and `feedPreRenderedAudio()` limits so audio and video share a single export length.
- Pass diagnostic info (raw vs aligned duration / frame count) into existing DIAG logs and make pre-rendering use the aligned duration to avoid audio/video end mismatches.
- Add unit tests `src/test/exportTimeline.test.ts` for the alignment utility and document the pattern in the implementation overview file `.agents/skills/turtle-video-overview/references/implementation-patterns.md`.

### Testing
- Ran the new unit test: `npm run test:run -- src/test/exportTimeline.test.ts`, which passed.
- Ran existing export tests: `npm run test:run -- src/test/useExport.test.ts`, which passed.
- Ran full test suite: `npm run test:run`, all tests passed (230 tests across 29 files succeeded).
- Performed production build: `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0f2d8327c83259f960aad6f2f6813)