### PR TITLE
Fix Teams export timing drift

### DIFF
--- a/.agents/skills/turtle-video-overview/references/implementation-patterns.md
+++ b/.agents/skills/turtle-video-overview/references/implementation-patterns.md
@@ -103,6 +103,20 @@
   - 非 iOS の滑らかさ問題を再調整する場合でも、映像の時間進行変更と音声プリレンダリング変更は切り離して評価する
   - iOS Safari の MediaRecorder 経路や preview 再生の時間管理には波及させない
 
+### 0-8. Teams 向け export は決定的なフレーム列を維持しつつ、最終フレームだけで総尺を合わせる
+
+- **ファイル**: `src/hooks/useExport.ts`, `src/utils/exportTimeline.ts`, `src/test/exportTimeline.test.ts`
+- **背景**:
+  - Teams デスクトップへの投稿後は再エンコード時の音声・映像の総尺差に敏感で、1 フレーム未満の延長でも「少し遅い」見え方へ繋がることがある
+  - 一方で全フレームの timestamp を実時間ベースへ戻すと、過去に潰した VFR ジッターが再発しやすい
+- **実装指針**:
+  - フレーム順序ベースの決定的 timestamp 採番は維持し、通常フレームの並びは壊さない
+  - export の総尺は raw timeline duration に合わせ、必要な端数は **最後の 1 フレームだけ** の duration で吸収する
+  - 音声のプリレンダリング長・AudioEncoder の終端 clamp も raw duration 基準へ揃え、映像側の切り上げ尺へ引っ張られないようにする
+- **注意点**:
+  - Teams 対策だからといって preview や iOS Safari MediaRecorder 経路へ同じ補正を広げない
+  - 総尺合わせを理由に `frameCount` 自体を減らすと最後の静止保持が欠けるため、フレーム数は維持して duration 配分だけを調整する
+
 ## 1. スクロール/スワイプ誤操作防止
 
 ### 1-1. モーダル表示時のボディスクロールロック

--- a/src/hooks/useExport.ts
+++ b/src/hooks/useExport.ts
@@ -9,7 +9,7 @@ import * as Mp4Muxer from 'mp4-muxer';
 import type { AudioTrack, NarrationClip } from '../types';
 import { useLogStore } from '../stores/logStore';
 import { getPlatformCapabilities } from '../utils/platform';
-import { alignExportDurationToFrameGrid } from '../utils/exportTimeline';
+import { alignExportDurationToFrameGrid, getExportFrameTiming } from '../utils/exportTimeline';
 import {
   resolveExportStrategyOrder,
   shouldUseOfflineAudioPreRender,
@@ -917,6 +917,7 @@ export function useExport(): UseExportReturn {
           hasBgm: !!audioSources.bgm,
           narrationCount: audioSources.narrations.length,
           totalDuration: Math.round(audioSources.totalDuration * 100) / 100,
+          rawDurationUs: exportTimelineAlignment?.rawDurationUs ?? null,
           alignedDurationSec: exportTimelineAlignment
             ? Math.round(exportTimelineAlignment.alignedDurationSec * 1000) / 1000
             : null,
@@ -951,7 +952,7 @@ export function useExport(): UseExportReturn {
       abortControllerRef.current = controller;
       const { signal } = controller;
       const maxAudioTimestampUs = exportTimelineAlignment
-        ? exportTimelineAlignment.alignedDurationUs
+        ? exportTimelineAlignment.rawDurationUs
         : Number.POSITIVE_INFINITY;
       const expectedVideoFrames = exportTimelineAlignment
         ? Math.max(1, exportTimelineAlignment.frameCount)
@@ -988,7 +989,7 @@ export function useExport(): UseExportReturn {
           return null;
         }
 
-        const preRenderedAudioDurationSec = exportTimelineAlignment?.alignedDurationSec ?? audioSources.totalDuration;
+        const preRenderedAudioDurationSec = exportTimelineAlignment?.rawDurationSec ?? audioSources.totalDuration;
 
         useLogStore.getState().info('RENDER', '[DIAG-3] OfflineAudioContext パス開始', {
           totalDuration: audioSources.totalDuration,
@@ -1251,7 +1252,7 @@ export function useExport(): UseExportReturn {
               renderedAudio,
               audioEncoder,
               signal,
-              exportTimelineAlignment?.alignedDurationSec ?? audioSources.totalDuration,
+              exportTimelineAlignment?.rawDurationSec ?? audioSources.totalDuration,
             );
             useLogStore.getState().info('RENDER', '[DIAG-5] feed完了後 AudioEncoder状態', {
               state: audioEncoder.state,
@@ -1553,7 +1554,6 @@ export function useExport(): UseExportReturn {
 
         const processVideoWithTrackProcessor = async () => {
           let frameIndex = 0;
-          const frameDuration = 1e6 / FPS; // 1フレームあたりの時間（マイクロ秒）
           const isKeyFrame = (index: number) => index === 0 || index % FPS === 0;
 
           try {
@@ -1586,14 +1586,20 @@ export function useExport(): UseExportReturn {
                   // [FIX] Teamsスロー再生対策
                   // オリジナルのtimestamp（実時間ベース）を使うと、レンダリング遅延（ジッター）が含まれ
                   // 結果としてVFR（可変フレームレート）となり、一部プレーヤーで再生時間が間延びする。
-                  // そのため、強制的にCFR（固定フレームレート）としてタイムスタンプを書き換える。
-                  const newTimestamp = Math.round(frameIndex * frameDuration);
+                  // そのため、フレーム順序ベースの決定的なタイムスタンプへ揃えつつ、
+                  // 総尺は生のタイムライン値へ一致させる。
+                  const frameTiming = exportTimelineAlignment
+                    ? getExportFrameTiming(exportTimelineAlignment, FPS, frameIndex)
+                    : {
+                      timestampUs: Math.round(frameIndex * (1e6 / FPS)),
+                      durationUs: Math.round(1e6 / FPS),
+                    };
 
                   // 新しいタイムスタンプでフレームを再作成
                   // copyToなどのコストを避けるため、VideoFrameコンストラクタでラップする
                   const newFrame = new VideoFrame(originalFrame, {
-                    timestamp: newTimestamp,
-                    duration: Math.round(frameDuration),
+                    timestamp: frameTiming.timestampUs,
+                    duration: frameTiming.durationUs,
                   });
 
                   // エンコード
@@ -1612,9 +1618,15 @@ export function useExport(): UseExportReturn {
             if (!signal.aborted && completionRequestedRef.current && expectedVideoFrames !== null && frameIndex < expectedVideoFrames && videoEncoder.state === 'configured') {
               const missingFrames = expectedVideoFrames - frameIndex;
               for (let i = 0; i < missingFrames; i++) {
+                const frameTiming = exportTimelineAlignment
+                  ? getExportFrameTiming(exportTimelineAlignment, FPS, frameIndex)
+                  : {
+                    timestampUs: Math.round(frameIndex * (1e6 / FPS)),
+                    durationUs: Math.round(1e6 / FPS),
+                  };
                 const frame = new VideoFrame(canvas, {
-                  timestamp: Math.round(frameIndex * frameDuration),
-                  duration: Math.round(frameDuration),
+                  timestamp: frameTiming.timestampUs,
+                  duration: frameTiming.durationUs,
                 });
                 videoEncoder.encode(frame, { keyFrame: isKeyFrame(frameIndex) });
                 frame.close();
@@ -1635,7 +1647,6 @@ export function useExport(): UseExportReturn {
 
         const processVideoWithCanvasFrames = async () => {
           let frameIndex = 0;
-          const frameDuration = 1e6 / FPS;
           const framePollInterval = 16;
           const isKeyFrame = (index: number) => index === 0 || index % FPS === 0;
 
@@ -1660,9 +1671,15 @@ export function useExport(): UseExportReturn {
 
               if (videoEncoder.state === 'configured' && framesToEncode > 0) {
                 for (let i = 0; i < framesToEncode; i++) {
+                  const frameTiming = exportTimelineAlignment
+                    ? getExportFrameTiming(exportTimelineAlignment, FPS, frameIndex)
+                    : {
+                      timestampUs: Math.round(frameIndex * (1e6 / FPS)),
+                      durationUs: Math.round(1e6 / FPS),
+                    };
                   const frame = new VideoFrame(canvas, {
-                    timestamp: Math.round(frameIndex * frameDuration),
-                    duration: Math.round(frameDuration),
+                    timestamp: frameTiming.timestampUs,
+                    duration: frameTiming.durationUs,
                   });
                   videoEncoder.encode(frame, { keyFrame: isKeyFrame(frameIndex) });
                   frame.close();
@@ -1830,7 +1847,7 @@ export function useExport(): UseExportReturn {
               renderedAudio,
               audioEncoder,
               signal,
-              exportTimelineAlignment?.alignedDurationSec ?? audioSources.totalDuration,
+              exportTimelineAlignment?.rawDurationSec ?? audioSources.totalDuration,
             );
             offlineAudioDone = true;
             useLogStore.getState().info('RENDER', 'OfflineAudioContext フォールバックで音声を補完', {

--- a/src/test/exportTimeline.test.ts
+++ b/src/test/exportTimeline.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { alignExportDurationToFrameGrid } from '../utils/exportTimeline';
+import { alignExportDurationToFrameGrid, getExportFrameTiming } from '../utils/exportTimeline';
 
 describe('alignExportDurationToFrameGrid', () => {
   it('フレーム境界ちょうどの尺はそのまま維持する', () => {
     expect(alignExportDurationToFrameGrid(2, 30)).toEqual({
       rawDurationSec: 2,
+      rawDurationUs: 2_000_000,
       frameCount: 60,
       alignedDurationSec: 2,
       alignedDurationUs: 2_000_000,
@@ -15,6 +16,7 @@ describe('alignExportDurationToFrameGrid', () => {
     const aligned = alignExportDurationToFrameGrid(10.01, 30);
 
     expect(aligned.rawDurationSec).toBe(10.01);
+    expect(aligned.rawDurationUs).toBe(10_010_000);
     expect(aligned.frameCount).toBe(301);
     expect(aligned.alignedDurationSec).toBeCloseTo(301 / 30, 10);
     expect(aligned.alignedDurationUs).toBe(Math.round((301 / 30) * 1e6));
@@ -30,5 +32,17 @@ describe('alignExportDurationToFrameGrid', () => {
   it('不正な入力はゼロ尺として扱う', () => {
     expect(alignExportDurationToFrameGrid(-1, 30).frameCount).toBe(0);
     expect(alignExportDurationToFrameGrid(10, 0).alignedDurationSec).toBe(0);
+  });
+
+  it('最終フレームだけを短くして総尺を元のタイムラインへ一致させる', () => {
+    const aligned = alignExportDurationToFrameGrid(10.01, 30);
+    const lastFrameIndex = aligned.frameCount - 1;
+    const penultimate = getExportFrameTiming(aligned, 30, lastFrameIndex - 1);
+    const last = getExportFrameTiming(aligned, 30, lastFrameIndex);
+
+    expect(penultimate.timestampUs + penultimate.durationUs).toBe(last.timestampUs);
+    expect(last.timestampUs + last.durationUs).toBe(aligned.rawDurationUs);
+    expect(last.durationUs).toBeLessThanOrEqual(Math.round(1e6 / 30));
+    expect(last.durationUs).toBeGreaterThan(0);
   });
 });

--- a/src/utils/exportTimeline.ts
+++ b/src/utils/exportTimeline.ts
@@ -1,8 +1,14 @@
 export interface ExportTimelineAlignment {
   rawDurationSec: number;
+  rawDurationUs: number;
   frameCount: number;
   alignedDurationSec: number;
   alignedDurationUs: number;
+}
+
+export interface ExportFrameTiming {
+  timestampUs: number;
+  durationUs: number;
 }
 
 const DURATION_EPSILON = 1e-9;
@@ -17,20 +23,49 @@ export function alignExportDurationToFrameGrid(
   if (safeDurationSec <= 0 || safeFps <= 0) {
     return {
       rawDurationSec: safeDurationSec,
+      rawDurationUs: 0,
       frameCount: 0,
       alignedDurationSec: 0,
       alignedDurationUs: 0,
     };
   }
 
+  const rawDurationUs = Math.max(0, Math.round(safeDurationSec * 1e6));
   const rawFrameCount = safeDurationSec * safeFps;
   const frameCount = Math.max(1, Math.ceil(rawFrameCount - DURATION_EPSILON));
   const alignedDurationSec = frameCount / safeFps;
 
   return {
     rawDurationSec: safeDurationSec,
+    rawDurationUs,
     frameCount,
     alignedDurationSec,
     alignedDurationUs: Math.max(0, Math.round(alignedDurationSec * 1e6)),
+  };
+}
+
+export function getExportFrameTiming(
+  alignment: ExportTimelineAlignment,
+  fps: number,
+  frameIndex: number,
+): ExportFrameTiming {
+  const safeFps = Number.isFinite(fps) && fps > 0 ? fps : 0;
+  if (alignment.frameCount <= 0 || safeFps <= 0 || frameIndex < 0 || frameIndex >= alignment.frameCount) {
+    return {
+      timestampUs: 0,
+      durationUs: 0,
+    };
+  }
+
+  const nominalFrameDurationUs = 1e6 / safeFps;
+  const timestampUs = Math.max(0, Math.round(frameIndex * nominalFrameDurationUs));
+  const isLastFrame = frameIndex === alignment.frameCount - 1;
+  const nextBoundaryUs = isLastFrame
+    ? alignment.rawDurationUs
+    : Math.max(timestampUs, Math.round((frameIndex + 1) * nominalFrameDurationUs));
+
+  return {
+    timestampUs,
+    durationUs: Math.max(1, nextBoundaryUs - timestampUs),
   };
 }


### PR DESCRIPTION
### Motivation
- 投稿先の Microsoft Teams で再エンコード後に再生がわずかに遅延して見える問題を解消するため、既存の決定的フレーム採番（CFR化）を維持しつつ書き出し総尺を元のタイムラインに厳密一致させる必要がありました。 
- 既存の iOS/非iOS のワークアラウンド（音声プリレンダリングや VFR ジッター対策）を壊さずに局所的に修正することを優先しました。 

### Description
- `src/utils/exportTimeline.ts` に raw duration のマイクロ秒表現 `rawDurationUs` を追加し、各フレームの決定的な `timestamp/duration` を返す `getExportFrameTiming` ヘルパーを実装しました。 
- `src/hooks/useExport.ts` を修正して、音声終端の clamp と OfflineAudioContext のプリレンダリング長を `alignedDuration` ではなく `rawDuration` 基準に揃え、`VideoFrame` の timestamp/duration を `getExportFrameTiming` で決定するようにして最終フレームだけで総尺の端数を吸収するようにしました。 
- テスト `src/test/exportTimeline.test.ts` を拡張して、最終フレームだけを短くして総尺が raw duration に一致することを検証するケースを追加しました。 
- 実装方針を `.agents/skills/turtle-video-overview/references/implementation-patterns.md` に追記して、今後の修正が過去対策を上書きしないよう知見を残しました。 

### Testing
- 単体テストを実行してターゲットのテストは全件成功し、`npm run test:run -- src/test/exportTimeline.test.ts src/test/useExport.test.ts` は成功しました。 
- リポジトリ全体のテストスイートを実行して全テストが成功し（複数ファイル、合計231件のテストがパスしました）。 
- ビルド確認として `npm run build` を実行し、TypeScript コンパイルと Vite ビルドが成功しました。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0fbbd42208325ab411f57dbf84b2f)