### PR TITLE
fix: Android エクスポート時の画像→動画境界を安定化

### DIFF
--- a/.agents/skills/turtle-video-overview/references/implementation-patterns.md
+++ b/.agents/skills/turtle-video-overview/references/implementation-patterns.md
@@ -1629,3 +1629,17 @@
 - **注意**:
   - 端数を切り捨てると末尾コンテンツを欠く可能性があるため、必ず切り上げる
   - 修正は export 専用に閉じ、preview 再生の時間進行や iOS Safari MediaRecorder 分岐の責務は変えない
+
+### 13-81. Android export の `画像 -> 動画` 境界は短時間だけ再生開始を抑止し、時刻同期を優先する
+
+- **ファイル**: `src/components/TurtleVideo.tsx`, `src/utils/previewPlatform.ts`, `src/test/previewPlatform.test.ts`
+- **問題**:
+  - Android で export 中に `画像 -> 動画` へ切り替わる瞬間、動画デコーダの立ち上がりと `play()` 再開が競合し、境界付近で映像が乱れる（プレビュー中は出にくいが書き出し結果で再現しやすい）ことがある
+  - このタイミングで通常の再生再開ロジックをそのまま適用すると、同期補正と再生開始が同時に走り、境界フレームが不安定になりやすい
+- **対策**:
+  - `shouldStabilizeImageToVideoTransitionDuringExport()` を追加し、export かつ `画像 -> 動画` の先頭 120ms だけ安定化モードに入る
+  - 安定化モードでは `play()` 再開を抑止し、`currentTime` を目標時刻へ強めに合わせることで、境界直後のフレーム確定を優先する
+  - 判定ロジックは utility 化して `previewPlatform` テストで固定し、将来のしきい値変更でも回帰を検知できるようにする
+- **注意**:
+  - 対策は export 中の境界区間に限定し、通常 preview や動画→動画遷移には適用しない
+  - 安定化ウィンドウを広げすぎると動画の立ち上がり体感を損なうため、最小限（120ms）を維持する

--- a/src/components/TurtleVideo.tsx
+++ b/src/components/TurtleVideo.tsx
@@ -46,6 +46,7 @@ import {
   getVisibilityRecoveryPlan,
   shouldHoldVideoFrameAtClipEnd,
   shouldKeepInactiveVideoPrewarmed,
+  shouldStabilizeImageToVideoTransitionDuringExport,
   shouldMuteNativeMediaElement,
   shouldReinitializeAudioRoute,
   shouldResumeAudioContextOnVisibilityReturn,
@@ -768,18 +769,19 @@ const TurtleVideo: React.FC = () => {
           if (!element || !conf) return;
 
           if (id === activeId) {
-            const isJustEnteredFromImageDuringExport =
-              conf.type === 'video'
-              && _isExporting
-              && activeIndex > 0
-              && currentItems[activeIndex - 1]?.type === 'image'
-              && localTime <= 0.05;
+            const shouldStabilizeImageToVideoTransition =
+              shouldStabilizeImageToVideoTransitionDuringExport({
+                isExporting: _isExporting,
+                activeItemType: conf.type,
+                previousItemType: activeIndex > 0 ? currentItems[activeIndex - 1]?.type ?? null : null,
+                clipLocalTime: localTime,
+              });
             // --- アクティブなメディアの処理 ---
             if (conf.type === 'video') {
               const videoEl = element as HTMLVideoElement;
               const targetTime = (conf.trimStart || 0) + localTime;
               const hasExportPlayFailure = _isExporting && !!exportPlayFailedRef.current[id];
-              const syncThreshold = isJustEnteredFromImageDuringExport
+              const syncThreshold = shouldStabilizeImageToVideoTransition
                 ? 0.01
                 : getPreviewVideoSyncThreshold(previewPlatformPolicy, {
                   isExporting: _isExporting,
@@ -806,6 +808,14 @@ const TurtleVideo: React.FC = () => {
               const isVideoSeeking = videoEl.seeking;
 
               if (isActivePlaying && !isUserSeeking) {
+                if (shouldStabilizeImageToVideoTransition) {
+                  if (!isVideoSeeking && Math.abs(videoEl.currentTime - targetTime) > 0.004) {
+                    videoEl.currentTime = targetTime;
+                  }
+                  if (!videoEl.paused) {
+                    videoEl.pause();
+                  }
+                }
                 // 再生中かつユーザーがシーク操作していない場合
                 // 終端付近でビデオが自然終了(ended)している場合は、
                 // sync と play() を抑止する。play() on ended はブラウザが
@@ -853,6 +863,7 @@ const TurtleVideo: React.FC = () => {
                 // ただし ended 状態のビデオへの play() は position 0 への
                 // シークを発動するため、終端付近では抑止する。
                 if (
+                  !shouldStabilizeImageToVideoTransition &&
                   videoEl.paused &&
                   videoEl.readyState >= 1 &&
                   !shouldHoldVideoAtClipEnd &&
@@ -988,7 +999,7 @@ const TurtleVideo: React.FC = () => {
                     currentGainNode.gain.setTargetAtTime(
                       effectiveGain,
                       audioCtxRef.current.currentTime,
-                      isJustEnteredFromImageDuringExport ? 0.01 : 0.05,
+                      shouldStabilizeImageToVideoTransition ? 0.01 : 0.05,
                     );
                   }
                 }

--- a/src/test/previewPlatform.test.ts
+++ b/src/test/previewPlatform.test.ts
@@ -15,6 +15,7 @@ import {
   shouldMuteNativeMediaElement,
   shouldReinitializeAudioRoute,
   shouldResumeAudioContextOnVisibilityReturn,
+  shouldStabilizeImageToVideoTransitionDuringExport,
   shouldUseCaptionBlurFallback,
 } from '../utils/previewPlatform';
 
@@ -266,6 +267,44 @@ describe('preview platform helpers', () => {
 
     expect(shouldMuteNativeMediaElement(androidPolicy, { hasAudioNode: true, isExporting: false })).toBe(false);
     expect(shouldMuteNativeMediaElement(androidPolicy, { hasAudioNode: true, isExporting: true })).toBe(true);
+  });
+
+  it('export の画像->動画境界だけ短時間の安定化モードに入る', () => {
+    expect(
+      shouldStabilizeImageToVideoTransitionDuringExport({
+        isExporting: true,
+        activeItemType: 'video',
+        previousItemType: 'image',
+        clipLocalTime: 0.08,
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldStabilizeImageToVideoTransitionDuringExport({
+        isExporting: true,
+        activeItemType: 'video',
+        previousItemType: 'image',
+        clipLocalTime: 0.18,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldStabilizeImageToVideoTransitionDuringExport({
+        isExporting: true,
+        activeItemType: 'video',
+        previousItemType: 'video',
+        clipLocalTime: 0.05,
+      }),
+    ).toBe(false);
+
+    expect(
+      shouldStabilizeImageToVideoTransitionDuringExport({
+        isExporting: false,
+        activeItemType: 'video',
+        previousItemType: 'image',
+        clipLocalTime: 0.05,
+      }),
+    ).toBe(false);
   });
 
   it('iOS Safari preview は単一動画だけ native 出力を維持し、動画+BGM では WebAudio mix に寄せる', () => {

--- a/src/utils/previewPlatform.ts
+++ b/src/utils/previewPlatform.ts
@@ -77,6 +77,14 @@ export interface FadeTailBlackoutGuardOptions {
   maxBlackoutWindowSec?: number;
 }
 
+export interface ExportImageToVideoStabilizationOptions {
+  isExporting: boolean;
+  activeItemType: 'video' | 'image' | null;
+  previousItemType: 'video' | 'image' | null;
+  clipLocalTime: number;
+  stabilizationWindowSec?: number;
+}
+
 /**
  * プラットフォーム capability から、プレビュー制御用の方針を組み立てる。
  */
@@ -376,6 +384,30 @@ export function shouldBlackoutVideoFadeTail(
   );
 
   return remainingClipTime <= blackoutWindowSec;
+}
+
+/**
+ * Android export で「画像 -> 動画」の直後は、デコーダが前クリップの状態から
+ * 立ち上がる途中に `play()`/sync が競合しやすい。短い安定化ウィンドウだけ
+ * 動画を時刻同期優先で扱うための判定を返す。
+ */
+export function shouldStabilizeImageToVideoTransitionDuringExport(
+  options: ExportImageToVideoStabilizationOptions,
+): boolean {
+  if (!options.isExporting) {
+    return false;
+  }
+
+  if (options.activeItemType !== 'video' || options.previousItemType !== 'image') {
+    return false;
+  }
+
+  const stabilizationWindowSec = options.stabilizationWindowSec ?? 0.12;
+  if (!Number.isFinite(stabilizationWindowSec) || stabilizationWindowSec <= 0) {
+    return false;
+  }
+
+  return options.clipLocalTime >= 0 && options.clipLocalTime <= stabilizationWindowSec;
 }
 
 /**


### PR DESCRIPTION
### Motivation
- Android でエクスポートするとき、`画像 -> 動画` の切替直後に書き出し結果で映像が乱れる現象があり、プレビューでは再現しないため export 専用の短時間安定化が必要と判断した。 
- 既存の Teams 向け AV 同期対策や iOS 用ワークアラウンドに影響を与えず、境界区間だけ対処することを目的とする。

### Description
- `src/utils/previewPlatform.ts` に `ExportImageToVideoStabilizationOptions` 型と `shouldStabilizeImageToVideoTransitionDuringExport()` を追加し、export 中かつ `画像 -> 動画` の先頭短時間（デフォルト 0.12s）だけ安定化モードを判定するユーティリティを実装した。 
- `src/components/TurtleVideo.tsx` の描画ループへ判定を組み込み、安定化モード中は `currentTime` を強めに同期して `play()` の再開を抑止し、オーディオゲインの時定数を短くすることで境界直後のフレーム確定を優先する変更を加えた。 
- 回帰検出のために `src/test/previewPlatform.test.ts` に判定ロジックのユニットテストを追加した。 
- 対応内容をオーバービュー参照資料（`.agents/skills/turtle-video-overview/references/implementation-patterns.md`）へ追記した。

### Testing
- 単体テストを実行し、追加テストを含む全テストがパスしました：`npm run test:run` → 29 ファイル、232 テストがすべて合格（全て成功）。
- 影響範囲を絞るため個別にも実行：`npm run test:run -- src/test/previewPlatform.test.ts` と `npm run test:run -- src/test/exportTimeline.test.ts` はそれぞれ成功。 
- ビルド確認を実行し成功しました：`npm run build` → ビルド完了（`vite build` 成功）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1e8497af883259c7bc4e6d5ead810)