### PR TITLE
Refresh SaveLoadModal relative times and tighten auto-save return cadence

### DIFF
--- a/.agents/skills/turtle-video-overview/references/implementation-patterns.md
+++ b/.agents/skills/turtle-video-overview/references/implementation-patterns.md
@@ -1657,3 +1657,31 @@
 - **注意点**:
   - 強制保存は IndexedDB 書き込み回数が増えるため、将来最適化する場合でも「起動・復帰直後の prompt save」と「export 中のみ抑止」の契約は維持する
   - `runAutoSave` の `force` パラメータを変更する場合は、`useAutoSave.test.tsx` のライフサイクル系テストを必ず更新して回帰を防ぐ
+
+### 13-83. 自動保存の復帰契機は「即時保存固定」ではなく overdue 判定で cadence を守る
+
+- **ファイル**: `src/hooks/useAutoSave.ts`, `src/test/useAutoSave.test.tsx`
+- **問題**:
+  - `visibilitychange` / `focus` / `pageshow` のたびに prompt save を強制すると、設定間隔（例: 5分）より短い周期で `savedAt` が更新され、保存UIが「たった今」に張り付きやすい
+  - 保存自体は成功していても、ユーザーからは「常時保存されているのか」「設定間隔が効いているのか」が判別しづらい
+- **対策**:
+  - 復帰契機の catch-up は `forcePromptSave` を使わず、`lastAutoSaveActivityAtRef` と設定間隔による overdue 判定でのみ実行する
+  - 非アクティブ復帰時は残り時間を維持するタイマー再開（timeout -> interval）を優先し、期限前は保存を走らせない
+  - 定周期 tick の `runAutoSave({ force: true })` は維持し、設定間隔どおりの強制保存契約を継続する
+- **注意点**:
+  - 保存失敗時は `lastAutoSaveActivityAtRef` を更新しないため、復帰イベントで overdue と判定されれば即時再試行が走る（失敗回復優先）
+  - 復帰即保存を戻したい場合は UI 表示要件（「n分前」表示）との整合を再定義してから反映する
+
+### 13-84. 保存モーダルの相対時刻は Date.now 基準で計算し、表示中だけ 30 秒ごとに更新する
+
+- **ファイル**: `src/components/modals/SaveLoadModal.tsx`, `src/test/modalHistoryStability.test.tsx`
+- **問題**:
+  - モーダルを開いたままだと React の再描画契機がなく、`たった今` / `3分前` などの相対時刻表示が固定される
+  - 端末時計ズレで `savedAt` が未来時刻になると、負の差分をそのまま扱うと不自然な表示になりやすい
+- **対策**:
+  - `formatDateTime()` を `Date.now()`（注入可能な `nowMs`）基準で差分計算し、負の差分は `0` に丸めて `たった今` として扱う
+  - SaveLoadModal が開いている間だけ `setInterval(30_000)` で相対時刻更新用 state を更新し、閉じたら即 cleanup する
+  - テストで「表示中に `たった今` -> `3分前` へ遷移すること」と「未来時刻が `たった今` 表示になること」を固定する
+- **注意点**:
+  - この更新は表示専用であり、保存タイミングや auto save cadence そのものは変更しない
+  - interval はモーダル表示中に限定し、閉じた状態での不要な再描画を発生させない

--- a/src/components/modals/SaveLoadModal.tsx
+++ b/src/components/modals/SaveLoadModal.tsx
@@ -50,11 +50,12 @@ const AUTO_SAVE_OPTIONS: { value: AutoSaveIntervalOption; label: string }[] = [
 /**
  * 日時を読みやすい形式にフォーマット
  */
-function formatDateTime(isoString: string | null): string {
+function formatDateTime(isoString: string | null, nowMs: number = Date.now()): string {
   if (!isoString) return '---';
   const date = new Date(isoString);
-  const now = new Date();
-  const diff = now.getTime() - date.getTime();
+  const savedAt = date.getTime();
+  if (!Number.isFinite(savedAt)) return '---';
+  const diff = Math.max(nowMs - savedAt, 0);
   
   // 1分未満
   if (diff < 60 * 1000) {
@@ -84,6 +85,7 @@ export default function SaveLoadModal({ isOpen, onClose, onToast }: SaveLoadModa
   const [selectedSlot, setSelectedSlot] = useState<SaveSlot | null>(null);
   const [autoSaveInterval, setAutoSaveIntervalState] = useState<AutoSaveIntervalOption>(getAutoSaveInterval);
   const [showHelp, setShowHelp] = useState(false);
+  const [relativeTimeNowMs, setRelativeTimeNowMs] = useState<number>(() => Date.now());
   const onCloseRef = useRef(onClose);
   const showHelpRef = useRef(false);
   const supportsShowSaveFilePicker = useMemo(
@@ -170,8 +172,19 @@ export default function SaveLoadModal({ isOpen, onClose, onToast }: SaveLoadModa
       setSelectedSlot(null);
       setAutoSaveIntervalState(getAutoSaveInterval());
       setShowHelp(false);
+      setRelativeTimeNowMs(Date.now());
     }
   }, [isOpen, refreshSaveInfo]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const timerId = window.setInterval(() => {
+      setRelativeTimeNowMs(Date.now());
+    }, 30_000);
+    return () => {
+      clearInterval(timerId);
+    };
+  }, [isOpen]);
 
   useEffect(() => {
     if (mode !== 'menu') {
@@ -627,7 +640,7 @@ export default function SaveLoadModal({ isOpen, onClose, onToast }: SaveLoadModa
                   自動保存
                 </span>
                 <span className={hasAutoSave ? 'text-white' : 'text-gray-500'}>
-                  {formatDateTime(lastAutoSave)}
+                  {formatDateTime(lastAutoSave, relativeTimeNowMs)}
                 </span>
               </div>
               <div className="flex items-center justify-between text-sm">
@@ -636,7 +649,7 @@ export default function SaveLoadModal({ isOpen, onClose, onToast }: SaveLoadModa
                   手動保存
                 </span>
                 <span className={hasManualSave ? 'text-white' : 'text-gray-500'}>
-                  {formatDateTime(lastManualSave)}
+                  {formatDateTime(lastManualSave, relativeTimeNowMs)}
                 </span>
               </div>
             </div>
@@ -741,7 +754,7 @@ export default function SaveLoadModal({ isOpen, onClose, onToast }: SaveLoadModa
                     自動保存
                   </span>
                   <span className="text-sm text-gray-400">
-                    {formatDateTime(lastAutoSave)}
+                    {formatDateTime(lastAutoSave, relativeTimeNowMs)}
                   </span>
                 </button>
               )}
@@ -756,7 +769,7 @@ export default function SaveLoadModal({ isOpen, onClose, onToast }: SaveLoadModa
                     手動保存
                   </span>
                   <span className="text-sm text-gray-400">
-                    {formatDateTime(lastManualSave)}
+                    {formatDateTime(lastManualSave, relativeTimeNowMs)}
                   </span>
                 </button>
               )}

--- a/src/hooks/useAutoSave.ts
+++ b/src/hooks/useAutoSave.ts
@@ -406,7 +406,7 @@ export function useAutoSave() {
         clearScheduledCatchUpSave();
         return;
       }
-      triggerCatchUpSave(true);
+      triggerCatchUpSave(false);
     };
 
     const handlePageHide = () => {
@@ -427,15 +427,15 @@ export function useAutoSave() {
       hasStartedAutoSaveTimerRef.current = true;
     }
     restartAutoSaveTimer(false);
-    triggerCatchUpSave(true);
+    triggerCatchUpSave(false);
 
     document.addEventListener('visibilitychange', handleVisibilityChange);
     window.addEventListener('pagehide', handlePageHide);
     const handleFocus = () => {
-      triggerCatchUpSave(true);
+      triggerCatchUpSave(false);
     };
     const handlePageShow = () => {
-      triggerCatchUpSave(true);
+      triggerCatchUpSave(false);
     };
     window.addEventListener('focus', handleFocus);
     window.addEventListener('pageshow', handlePageShow);

--- a/src/test/modalHistoryStability.test.tsx
+++ b/src/test/modalHistoryStability.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render } from '@testing-library/react';
+import { act, cleanup, fireEvent, render } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import SettingsModal from '../components/modals/SettingsModal';
 import SaveLoadModal from '../components/modals/SaveLoadModal';
@@ -41,8 +41,8 @@ const updateStoreState = {
 const projectStoreState = {
   isSaving: false,
   isLoading: false,
-  lastAutoSave: null,
-  lastManualSave: null,
+  lastAutoSave: null as string | null,
+  lastManualSave: null as string | null,
   lastSaveFailure: null as null | {
     operation: 'manual' | 'auto';
     reason: string;
@@ -257,5 +257,31 @@ describe('modal history stability', () => {
       expect(onToast).toHaveBeenCalledWith('保存しました', 'success');
       expect(onClose).toHaveBeenCalledTimes(1);
     });
+  });
+
+  it('SaveLoadModal は表示中に相対時刻表示を更新し、将来時刻は「たった今」に丸める', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-24T12:00:00.000Z'));
+    projectStoreState.lastAutoSave = '2026-03-24T11:59:10.000Z';
+    projectStoreState.lastManualSave = '2026-03-24T12:10:00.000Z';
+
+    const { getAllByText } = render(
+      <SaveLoadModal
+        isOpen={true}
+        onClose={() => {}}
+        onToast={() => {}}
+      />,
+    );
+
+    expect(getAllByText('たった今').length).toBeGreaterThanOrEqual(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(150_000);
+    });
+
+    expect(getAllByText('3分前').length).toBeGreaterThanOrEqual(1);
+    expect(getAllByText('たった今').length).toBeGreaterThanOrEqual(1);
+
+    vi.useRealTimers();
   });
 });

--- a/src/test/useAutoSave.test.tsx
+++ b/src/test/useAutoSave.test.tsx
@@ -281,10 +281,10 @@ describe('useAutoSave', () => {
       await Promise.resolve();
     });
 
-    expect(saveProjectAuto).toHaveBeenCalledTimes(2);
+    expect(saveProjectAuto).toHaveBeenCalledTimes(1);
   });
 
-  it('短時間の非アクティブ復帰では残り時間を維持して自動保存 cadence を保つ', async () => {
+  it('短時間の非アクティブ復帰では残り時間を維持し、期限前の即時保存は行わない', async () => {
     const refreshSaveInfo = vi.fn().mockResolvedValue(undefined);
     const saveProjectAuto = vi.fn().mockResolvedValue(true);
     const setIntervalSpy = vi.spyOn(window, 'setInterval');
@@ -326,7 +326,7 @@ describe('useAutoSave', () => {
     });
 
     expect(setTimeoutSpy).toHaveBeenCalled();
-    expect(saveProjectAuto).toHaveBeenCalledTimes(1);
+    expect(saveProjectAuto).not.toHaveBeenCalled();
 
     act(() => {
       useCaptionStore.setState({
@@ -344,7 +344,14 @@ describe('useAutoSave', () => {
     });
 
     await act(async () => {
-      vi.advanceTimersByTime(61_000);
+      vi.advanceTimersByTime(10_000);
+      await Promise.resolve();
+    });
+
+    expect(saveProjectAuto).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(60_000);
       await Promise.resolve();
     });
 
@@ -443,7 +450,7 @@ describe('useAutoSave', () => {
     expect(saveProjectAuto).toHaveBeenCalledTimes(2);
   });
 
-  it('自動保存失敗時は復帰契機の catch-up 保存を即座に再試行できる', async () => {
+  it('自動保存失敗時は復帰契機で overdue なら即時に再試行できる', async () => {
     const refreshSaveInfo = vi.fn().mockResolvedValue(undefined);
     const saveProjectAuto = vi
       .fn<() => Promise<boolean>>()


### PR DESCRIPTION
### Motivation

- Improve user-visible relative timestamps in the save modal so they don't freeze while the modal is open and to avoid awkward future timestamps. 
- Prevent automatic forced saves on every `visibilitychange`/`focus`/`pageshow` event so the configured auto-save cadence (`overdue` logic) is preserved. 
- Make the behaviour testable and stable by injecting a time basis and updating tests to assert the new cadence and display semantics.

### Description

- Changed `formatDateTime` to accept an injectable `nowMs` and clamp negative diffs to `0` to treat future `savedAt` values as `たった今` in `src/components/modals/SaveLoadModal.tsx`. 
- Added `relativeTimeNowMs` state and a `setInterval(30_000)` that runs only while the modal is open to refresh relative-time displays every 30s in `SaveLoadModal`. 
- Replaced calls to `formatDateTime(last..., relativeTimeNowMs)` throughout the modal render. 
- Adjusted auto-save return handling in `src/hooks/useAutoSave.ts` to call `triggerCatchUpSave(false)` (no immediate forced save) for `visibilitychange`/`focus`/`pageshow` and on init, so catch-up runs only when the `overdue` check requires it. 
- Updated tests and imports: added/adjusted tests in `src/test/modalHistoryStability.test.tsx` and `src/test/useAutoSave.test.tsx` to reflect the new timing/display behavior and adjusted expectations; added `act` import and stronger typings for `lastAutoSave`/`lastManualSave` in the modal test state. 
- Document updates in `.agents/skills/turtle-video-overview/references/implementation-patterns.md` describing the autosave and preview/export stability considerations.

### Testing

- Ran unit tests with `vitest`; updated `modalHistoryStability.test.tsx` to verify timed updates and future-time clamping and the test passed. 
- Updated `useAutoSave.test.tsx` expectations to reflect that short return events do not trigger immediate saves and those tests passed after adjustments. 
- Ran the full test suite and relevant autosave/modal tests locally and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2888efc5883258fe4703855213938)