### PR TITLE
standard previewの再生時刻をperformance.now基準へ変更してAndroid/PCの再生カクつきを軽減

### DIFF
--- a/.github/skills/turtle-video-overview/references/implementation-patterns.md
+++ b/.github/skills/turtle-video-overview/references/implementation-patterns.md
@@ -1687,3 +1687,14 @@
   - `refreshSaveInfo()` は保存先 DB の最終保存時刻しか知らないため、`skipped-nochange` などで進んだ runtime 活動時刻を上書きしない
   - 手動保存で autosave cadence の基準をリセットする場合も、正確な「前回 auto 保存日時」は `lastAutoSave` 側で保持し続ける
   - 手動保存直後の `autoSaveRuntimeStatus` は autosave 成功扱いにせず、待機状態へ戻して「直近の自動保存が完了した」と誤表示しない
+
+### 13-72. standard preview の再生時刻計測は `performance.now()` を優先し、Android/PC のコマ落ち体感を抑える
+
+- **対象ファイル**: `src/flavors/standard/preview/usePreviewEngine.ts`
+- **問題**:
+  - standard preview の再生ループが `Date.now()` 基準だと、端末やブラウザ負荷時の時刻分解能・ドリフトの影響で描画間隔が粗くなり、Android/PC で「パラパラ漫画」のように見えるケースがある。
+- **対応パターン**:
+  - standard preview の loop 時刻計測と `startTimeRef` 初期化を `performance.now()` 優先へ変更する（fallback は `Date.now()`）。
+  - monotonic な高精度時刻を使い、フレーム進行の微小な揺れを減らす。
+- **注意**:
+  - 本変更は `src/flavors/standard/preview/` のみで適用し、`src/flavors/apple-safari/preview/` には適用しない（Safari 経路の挙動非変更を維持）。

--- a/src/flavors/standard/preview/usePreviewEngine.ts
+++ b/src/flavors/standard/preview/usePreviewEngine.ts
@@ -1524,7 +1524,7 @@ export function usePreviewEngine({
         return;
       }
 
-      const now = Date.now();
+      const now = typeof performance !== "undefined" ? performance.now() : Date.now();
       const elapsed = (now - startTimeRef.current) / 1000;
       const clampedElapsed = Math.min(elapsed, totalDurationRef.current);
 
@@ -2103,7 +2103,7 @@ export function usePreviewEngine({
         primePreviewAudioOnlyTracksAtTime(fromTime);
       }
 
-      startTimeRef.current = Date.now() - fromTime * 1000;
+      startTimeRef.current = (typeof performance !== "undefined" ? performance.now() : Date.now()) - fromTime * 1000;
 
       if (isExportMode && canvasRef.current && masterDestRef.current) {
         startWebCodecsExport(
@@ -2132,7 +2132,7 @@ export function usePreviewEngine({
             getPlaybackTimeSec: () => currentTimeRef.current,
             onPreparationStepChange: setExportPreparationStep,
             onAudioPreRenderComplete: () => {
-              startTimeRef.current = Date.now() - fromTime * 1000;
+              startTimeRef.current = (typeof performance !== "undefined" ? performance.now() : Date.now()) - fromTime * 1000;
               loop(isExportMode, myLoopId);
             },
           },


### PR DESCRIPTION
### Motivation
- Android/PC（standard preview）で再生が「パラパラ漫画」のようにカクつく事象を軽減するため、再生ループの時刻基準を高精度化して体感の揺れを減らす意図です。 
- Safari（apple-safari）側の挙動には一切影響を与えないよう、standard flavor のみを対象に修正します。

### Description
- `src/flavors/standard/preview/usePreviewEngine.ts` の再生ループ内で `Date.now()` を `performance.now()` 優先（fallback は `Date.now()`）に置換し、経過時間計測を高精度化しました。 
- 再生開始やエクスポート準備完了後の `startTimeRef` 初期化も同じ高精度基準に統一しました。 
- 実装パターン文書に今回の注意点を追記し `.github/skills/turtle-video-overview/references/implementation-patterns.md` に「13-72」を追加しました。 
- 変更は `src/flavors/standard/preview/` のみで、`src/flavors/apple-safari/` には変更を加えていません。

### Testing
- 自動テストを `npm run test:run` で実行し、44 files / 312 tests が全て合格しました（すべて成功）。
- ビルドを `npm run build`（`tsc` + `vite build`）で実行し、プロダクションビルドが成功しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f17c66e21c8325bf62dd3dd032afa0)