### PR TITLE
Android プレビュー: シーク後の再生復帰をリトライで安定化

### DIFF
--- a/src/flavors/standard/preview/usePreviewSeekController.ts
+++ b/src/flavors/standard/preview/usePreviewSeekController.ts
@@ -103,6 +103,24 @@ export function usePreviewSeekController({
   preparePreviewAudioNodesForTime,
   primePreviewAudioOnlyTracksAtTime,
 }: UsePreviewSeekControllerParams): UsePreviewSeekControllerResult {
+  const requestVideoPlayWithRetry = useCallback((videoElement: HTMLVideoElement, retryIntervalMs = 160) => {
+    const maxRetryCount = 4;
+    const tryPlay = (attempt: number) => {
+      if (!isPlayingRef.current || isSeekingRef.current || !videoElement.paused) return;
+      if (videoElement.readyState === 0 && !videoElement.error) {
+        try { videoElement.load(); } catch { /* ignore */ }
+      }
+      if (videoElement.readyState >= 2 && !videoElement.seeking) {
+        videoElement.play().catch(() => {
+          if (attempt < maxRetryCount) setTimeout(() => tryPlay(attempt + 1), retryIntervalMs);
+        });
+        return;
+      }
+      if (attempt < maxRetryCount) setTimeout(() => tryPlay(attempt + 1), retryIntervalMs);
+    };
+    tryPlay(1);
+  }, [isPlayingRef, isSeekingRef]);
+
   const syncVideoToTime = useCallback((time: number, options?: { force?: boolean }) => {
     const force = options?.force ?? false;
     const seekThreshold = force ? 0.01 : 0.1;
@@ -487,7 +505,7 @@ export function usePreviewSeekController({
 
                 if (shouldPrimeActiveVideo) {
                   if (videoElement.readyState >= 2 && !videoElement.seeking) {
-                    videoElement.play().catch(() => {});
+                    requestVideoPlayWithRetry(videoElement);
                   } else {
                     const playWhenReady = () => {
                       if (!shouldAttemptDeferredPreviewPlay({
@@ -500,7 +518,7 @@ export function usePreviewSeekController({
                         return;
                       }
                       if (videoElement.paused) {
-                        videoElement.play().catch(() => {});
+                        requestVideoPlayWithRetry(videoElement);
                       }
                     };
 
@@ -517,7 +535,7 @@ export function usePreviewSeekController({
                         mediaSeeking: videoElement.seeking,
                         readyState: videoElement.readyState,
                       }) && videoElement.paused) {
-                        videoElement.play().catch(() => {});
+                        requestVideoPlayWithRetry(videoElement);
                       }
                     }, 1000);
                   }
@@ -533,7 +551,7 @@ export function usePreviewSeekController({
 
         if (shouldBundlePreviewStart && activeVideoElementForBundledStart) {
           if (activeVideoElementForBundledStart.readyState >= 2 && !activeVideoElementForBundledStart.seeking) {
-            activeVideoElementForBundledStart.play().catch(() => {});
+            requestVideoPlayWithRetry(activeVideoElementForBundledStart);
           } else {
             const playWhenReady = () => {
               if (!shouldAttemptDeferredPreviewPlay({
@@ -547,7 +565,7 @@ export function usePreviewSeekController({
                 return;
               }
               if (activeVideoElementForBundledStart.paused) {
-                activeVideoElementForBundledStart.play().catch(() => {});
+                requestVideoPlayWithRetry(activeVideoElementForBundledStart);
               }
             };
             activeVideoElementForBundledStart.addEventListener('canplay', playWhenReady, { once: true });
@@ -762,6 +780,7 @@ export function usePreviewSeekController({
     previewPlatformPolicy,
     previewPlaybackAttemptRef,
     primePreviewAudioOnlyTracksAtTime,
+    requestVideoPlayWithRetry,
     cancelSeekPlaybackPrepareRef,
     renderFrame,
     reqIdRef,


### PR DESCRIPTION
### Motivation
- Android 環境でシーク操作後に再生が復帰せず黒画面やフレーム更新失敗（かくつき）を起こす事象が発生しており、プレビュー再生の復帰処理を堅牢にする必要があった。 

### Description
- `usePreviewSeekController` に `requestVideoPlayWithRetry` を追加し、`play()` を複数回リトライして再生復帰の成功率を高める実装を行った。 
- `readyState === 0` かつエラーがない場合に `load()` を再実行してデコーダ準備を促進し、必要に応じて短時間間隔で再試行するようにした。 
- シーク終了時の再生開始経路（通常開始 / deferred 開始 / bundled 開始）で直接の `video.play().catch(...)` 呼び出しを `requestVideoPlayWithRetry` に置換し、Hook の依存配列へ関数を追加した。 

### Testing
- 実行した自動テストは `npm run test:run -- src/test/playbackTimeline.test.ts src/test/previewRuntimeIsolation.test.ts src/test/previewRuntimeCapabilities.test.ts` で、3 ファイル合計 9 テストがすべて成功した（3 files / 9 tests passed）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1843196488325b0a683eb570e889d)