### PR TITLE
Android プレビューの再生復帰を強化してカクつき/ブラックアウト/音飛びを抑止

### DIFF
--- a/.agents/skills/turtle-video-overview/references/implementation-patterns.md
+++ b/.agents/skills/turtle-video-overview/references/implementation-patterns.md
@@ -1763,3 +1763,16 @@
 - **注意点**:
   - retry 条件を `previewPlatform.ts` に寄せ、Android / PC / export では必ず `false` になるテストを入れて共有経路への漏れを防ぐ。
   - これは「静止画先頭の audio-only 起動を安定させる」ための補強であり、動画側の start 順や boundary recovery と混ぜて一般化しない。
+
+### 13-91. Android preview の active video が pause/seek 残留した場合は即時リカバリする
+
+- **ファイル**: `src/flavors/standard/preview/usePreviewEngine.ts`, `src/utils/previewPlatform.ts`, `src/test/previewPlatform.test.ts`
+- **問題**:
+  - Android preview で active video が `paused=true` や `seeking=true` に残留すると、Canvas 側は再生中の想定で進む一方で映像デコーダが追従せず、ブラックアウト・カクつき・音飛びを誘発しやすい。
+- **対策**:
+  - `shouldRecoverAndroidPreviewVideoPlayback()` を追加し、Android preview かつ active 再生中だけ「pause/seek/readyState不足」を復帰対象として判定する。
+  - `usePreviewEngine` の active video 制御で上記判定が true の場合、短い間隔で `load()` / `play()` を再試行してデコーダ停止を自己回復させる。
+  - export/iOS/ユーザーseek中には適用しないガードを helper 側に集約する。
+- **注意点**:
+  - 復帰再試行間隔を短くしすぎると `play()` 連打で逆効果になるため、約 220ms の最小間隔を維持する。
+  - Android preview 専用ロジックを共通経路へ広げない。

--- a/src/flavors/standard/preview/previewPlatform.ts
+++ b/src/flavors/standard/preview/previewPlatform.ts
@@ -103,6 +103,17 @@ export interface ExportImageToVideoFrameHoldOptions extends ExportImageToVideoSt
   syncToleranceSec?: number;
 }
 
+export interface AndroidPreviewVideoRecoveryOptions {
+  isAndroid: boolean;
+  isExporting: boolean;
+  isActivePlaying: boolean;
+  isUserSeeking: boolean;
+  videoPaused: boolean;
+  videoSeeking: boolean;
+  videoReadyState: number;
+  readyStateFloor?: number;
+}
+
 // HTMLMediaElement.HAVE_CURRENT_DATA 相当。現在フレームを canvas 描画に使える最小 readyState。
 const MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME: HTMLMediaElement['readyState'] =
   typeof HTMLMediaElement !== 'undefined'
@@ -612,4 +623,14 @@ export function getPageHidePausePlan(options: {
   return {
     shouldPauseMediaElements: !options.isProcessing,
   };
+}
+
+export function shouldRecoverAndroidPreviewVideoPlayback(
+  options: AndroidPreviewVideoRecoveryOptions,
+): boolean {
+  if (!options.isAndroid || options.isExporting) return false;
+  if (!options.isActivePlaying || options.isUserSeeking) return false;
+
+  const readyStateFloor = options.readyStateFloor ?? MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME;
+  return options.videoPaused || options.videoSeeking || options.videoReadyState < readyStateFloor;
 }

--- a/src/flavors/standard/preview/usePreviewEngine.ts
+++ b/src/flavors/standard/preview/usePreviewEngine.ts
@@ -30,6 +30,7 @@ import {
   shouldKeepInactiveVideoPrewarmed,
   shouldMuteNativeMediaElement,
   shouldPrimeFutureInactiveVideoInPreview,
+  shouldRecoverAndroidPreviewVideoPlayback,
   shouldRecoverAudioOnlyAfterVideoBoundary,
   shouldReinitializeAudioRoute,
   shouldRetryAudioOnlyPrimeAtPreviewStart,
@@ -916,6 +917,29 @@ export function usePreviewEngine({
                       });
                     }
                   });
+                }
+
+                const shouldRecoverAndroidPlayback = shouldRecoverAndroidPreviewVideoPlayback({
+                  isAndroid: platformCapabilities.isAndroid,
+                  isExporting: _isExporting,
+                  isActivePlaying,
+                  isUserSeeking,
+                  videoPaused: videoEl.paused,
+                  videoSeeking: isVideoSeeking,
+                  videoReadyState: videoEl.readyState,
+                });
+                if (shouldRecoverAndroidPlayback) {
+                  const now = Date.now();
+                  const lastAttempt = videoRecoveryAttemptsRef.current[id] || 0;
+                  if (now - lastAttempt > 220) {
+                    videoRecoveryAttemptsRef.current[id] = now;
+                    if (videoEl.readyState === 0 && !videoEl.error) {
+                      try { videoEl.load(); } catch { /* ignore */ }
+                    }
+                    if (!isVideoSeeking && videoEl.readyState >= MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME) {
+                      videoEl.play().catch(() => { /* ignore */ });
+                    }
+                  }
                 }
               } else if (!isActivePlaying && !isUserSeeking) {
                 if (!videoEl.paused) {

--- a/src/test/previewPlatform.test.ts
+++ b/src/test/previewPlatform.test.ts
@@ -16,6 +16,7 @@ import {
   shouldKeepInactiveVideoPrewarmed,
   shouldMuteNativeMediaElement,
   shouldPrimeFutureInactiveVideoInPreview,
+  shouldRecoverAndroidPreviewVideoPlayback,
   shouldRecoverAudioOnlyAfterVideoBoundary,
   shouldRetryAudioOnlyPrimeAtPreviewStart,
   shouldReinitializeAudioRoute,
@@ -687,6 +688,78 @@ describe('preview platform helpers', () => {
         isVideoSeeking: true,
         videoCurrentTime: 0,
         targetTime: 0.02,
+      }),
+    ).toBe(false);
+  });
+
+  it('Android preview の active video が pause/seek/未準備なら復帰アクション判定を返す', () => {
+    expect(
+      shouldRecoverAndroidPreviewVideoPlayback({
+        isAndroid: true,
+        isExporting: false,
+        isActivePlaying: true,
+        isUserSeeking: false,
+        videoPaused: true,
+        videoSeeking: false,
+        videoReadyState: 2,
+      }),
+    ).toBe(true);
+    expect(
+      shouldRecoverAndroidPreviewVideoPlayback({
+        isAndroid: true,
+        isExporting: false,
+        isActivePlaying: true,
+        isUserSeeking: false,
+        videoPaused: false,
+        videoSeeking: true,
+        videoReadyState: 2,
+      }),
+    ).toBe(true);
+    expect(
+      shouldRecoverAndroidPreviewVideoPlayback({
+        isAndroid: true,
+        isExporting: false,
+        isActivePlaying: true,
+        isUserSeeking: false,
+        videoPaused: false,
+        videoSeeking: false,
+        videoReadyState: 1,
+      }),
+    ).toBe(true);
+  });
+
+  it('Android 以外・export・ユーザーseek中は復帰アクション判定を抑止する', () => {
+    expect(
+      shouldRecoverAndroidPreviewVideoPlayback({
+        isAndroid: false,
+        isExporting: false,
+        isActivePlaying: true,
+        isUserSeeking: false,
+        videoPaused: true,
+        videoSeeking: false,
+        videoReadyState: 2,
+      }),
+    ).toBe(false);
+    expect(
+      shouldRecoverAndroidPreviewVideoPlayback({
+        isAndroid: true,
+        isExporting: true,
+        isActivePlaying: true,
+        isUserSeeking: false,
+        videoPaused: true,
+        videoSeeking: false,
+        videoReadyState: 2,
+      }),
+    ).toBe(false);
+    expect(
+      shouldRecoverAndroidPreviewVideoPlayback({
+        isAndroid: true,
+        isExporting: false,
+        isActivePlaying: true,
+        isUserSeeking: true,
+        videoPaused: true,
+        videoSeeking: false,
+        videoReadyState: 2,
       }),
     ).toBe(false);
   });

--- a/src/utils/previewPlatform.ts
+++ b/src/utils/previewPlatform.ts
@@ -104,6 +104,17 @@ export interface ExportImageToVideoFrameHoldOptions extends ExportImageToVideoSt
   syncToleranceSec?: number;
 }
 
+export interface AndroidPreviewVideoRecoveryOptions {
+  isAndroid: boolean;
+  isExporting: boolean;
+  isActivePlaying: boolean;
+  isUserSeeking: boolean;
+  videoPaused: boolean;
+  videoSeeking: boolean;
+  videoReadyState: number;
+  readyStateFloor?: number;
+}
+
 // HTMLMediaElement.HAVE_CURRENT_DATA 相当。現在フレームを canvas 描画に使える最小 readyState。
 const MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME: HTMLMediaElement['readyState'] =
   typeof HTMLMediaElement !== 'undefined'
@@ -666,4 +677,14 @@ export function getPageHidePausePlan(options: {
   return {
     shouldPauseMediaElements: !options.isProcessing,
   };
+}
+
+export function shouldRecoverAndroidPreviewVideoPlayback(
+  options: AndroidPreviewVideoRecoveryOptions,
+): boolean {
+  if (!options.isAndroid || options.isExporting) return false;
+  if (!options.isActivePlaying || options.isUserSeeking) return false;
+
+  const readyStateFloor = options.readyStateFloor ?? MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME;
+  return options.videoPaused || options.videoSeeking || options.videoReadyState < readyStateFloor;
 }


### PR DESCRIPTION
### Motivation
- Android のプレビューで active video が `paused` / `seeking` / `readyState`不足のまま取り残されると、Canvas 側の時間進行とデコーダ状態の乖離で黒画面や再生のカクつき、音飛びが発生していたため、Android 側のルート処理だけで復帰を図る必要があった。

### Description
- `previewPlatform` に `shouldRecoverAndroidPreviewVideoPlayback` ヘルパーを追加し、Android + preview + active 再生中 + 非ユーザーseek の条件でのみ復帰判定を行うようにした（`src/utils/previewPlatform.ts` / `src/flavors/standard/preview/previewPlatform.ts`）。
- `usePreviewEngine` の active video 制御に上記判定を組み込み、短い間隔（最小約220ms）で `load()` / `play()` の再試行を行ってデコーダ停止残留を自己回復させる処理を追加した（`src/flavors/standard/preview/usePreviewEngine.ts`）。
- ユニットテストを追加して判定の発火／抑止条件を固定化し、policy の挙動を明確化した（`src/test/previewPlatform.test.ts`）。
- 実装パターンドキュメントに今回の対策を追記してナレッジ化した（`.agents/skills/turtle-video-overview/references/implementation-patterns.md`）。

### Testing
- `npm run test:run -- src/test/previewPlatform.test.ts` を実行し、該当テストファイルの全 52 件が合格したことを確認した（成功）。
- `npm run build` を実行し、TypeScript コンパイルと Vite ビルドが成功してプロダクションビルドが完了することを確認した（成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1c05ab398832592006800d85630a6)