### PR TITLE
Add Android preview recovery decision helper and engine integration

### DIFF
--- a/src/flavors/standard/preview/previewPlatform.ts
+++ b/src/flavors/standard/preview/previewPlatform.ts
@@ -105,6 +105,7 @@ export interface ExportImageToVideoFrameHoldOptions extends ExportImageToVideoSt
 
 export interface AndroidPreviewVideoRecoveryOptions {
   isAndroid: boolean;
+  isIosSafari?: boolean;
   isExporting: boolean;
   isActivePlaying: boolean;
   isUserSeeking: boolean;
@@ -112,6 +113,43 @@ export interface AndroidPreviewVideoRecoveryOptions {
   videoSeeking: boolean;
   videoReadyState: number;
   readyStateFloor?: number;
+}
+
+export type AndroidPreviewRecoveryReason =
+  | 'paused-during-playback'
+  | 'seeking-during-playback'
+  | 'ready-state-low'
+  | 'dimension-zero'
+  | 'timeline-drift'
+  | 'play-retry-pending'
+  | 'waiting-canplay'
+  | 'waiting-seeked'
+  | 'waiting-loadeddata';
+
+export interface AndroidPreviewRecoveryDecisionOptions {
+  isAndroid: boolean;
+  isIosSafari: boolean;
+  isExporting: boolean;
+  isActivePlaying: boolean;
+  isUserSeeking: boolean;
+  videoPaused: boolean;
+  videoSeeking: boolean;
+  videoReadyState: number;
+  videoWidth: number;
+  videoHeight: number;
+  videoCurrentTime: number;
+  targetTime: number;
+  syncThresholdSec?: number;
+  readyStateFloor?: number;
+}
+
+export interface AndroidPreviewRecoveryDecision {
+  shouldRecover: boolean;
+  shouldHoldFrame: boolean;
+  shouldRetryPlay: boolean;
+  shouldResyncTime: boolean;
+  shouldRebaseClockAfterReady: boolean;
+  reason: AndroidPreviewRecoveryReason | null;
 }
 
 // HTMLMediaElement.HAVE_CURRENT_DATA 相当。現在フレームを canvas 描画に使える最小 readyState。
@@ -628,9 +666,42 @@ export function getPageHidePausePlan(options: {
 export function shouldRecoverAndroidPreviewVideoPlayback(
   options: AndroidPreviewVideoRecoveryOptions,
 ): boolean {
-  if (!options.isAndroid || options.isExporting) return false;
-  if (!options.isActivePlaying || options.isUserSeeking) return false;
+  return getAndroidPreviewRecoveryDecision({
+    isAndroid: options.isAndroid,
+    isIosSafari: options.isIosSafari ?? false,
+    isExporting: options.isExporting,
+    isActivePlaying: options.isActivePlaying,
+    isUserSeeking: options.isUserSeeking,
+    videoPaused: options.videoPaused,
+    videoSeeking: options.videoSeeking,
+    videoReadyState: options.videoReadyState,
+    videoWidth: 1,
+    videoHeight: 1,
+    videoCurrentTime: 0,
+    targetTime: 0,
+    readyStateFloor: options.readyStateFloor,
+  }).shouldRecover;
+}
 
+export function getAndroidPreviewRecoveryDecision(
+  options: AndroidPreviewRecoveryDecisionOptions,
+): AndroidPreviewRecoveryDecision {
   const readyStateFloor = options.readyStateFloor ?? MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME;
-  return options.videoPaused || options.videoSeeking || options.videoReadyState < readyStateFloor;
+  const syncThresholdSec = options.syncThresholdSec ?? 0.25;
+  const empty: AndroidPreviewRecoveryDecision = {
+    shouldRecover: false,
+    shouldHoldFrame: false,
+    shouldRetryPlay: false,
+    shouldResyncTime: false,
+    shouldRebaseClockAfterReady: false,
+    reason: null,
+  };
+  if (!options.isAndroid || options.isIosSafari) return empty;
+  if (options.isExporting || !options.isActivePlaying || options.isUserSeeking) return empty;
+  if (options.videoPaused) return { ...empty, shouldRecover: true, shouldHoldFrame: true, shouldRetryPlay: true, shouldRebaseClockAfterReady: true, reason: 'paused-during-playback' };
+  if (options.videoSeeking) return { ...empty, shouldRecover: true, shouldHoldFrame: true, shouldRebaseClockAfterReady: true, reason: 'seeking-during-playback' };
+  if (options.videoReadyState < readyStateFloor) return { ...empty, shouldRecover: true, shouldHoldFrame: true, shouldRebaseClockAfterReady: true, reason: 'ready-state-low' };
+  if (options.videoWidth <= 0 || options.videoHeight <= 0) return { ...empty, shouldRecover: true, shouldHoldFrame: true, shouldRebaseClockAfterReady: true, reason: 'dimension-zero' };
+  if (Math.abs(options.videoCurrentTime - options.targetTime) > syncThresholdSec) return { ...empty, shouldRecover: true, shouldHoldFrame: true, shouldResyncTime: true, shouldRebaseClockAfterReady: true, reason: 'timeline-drift' };
+  return empty;
 }

--- a/src/flavors/standard/preview/usePreviewEngine.ts
+++ b/src/flavors/standard/preview/usePreviewEngine.ts
@@ -1,4 +1,4 @@
-import { useCallback, type MutableRefObject } from 'react';
+import { useCallback, useRef, type MutableRefObject } from 'react';
 
 import {
   CANVAS_HEIGHT,
@@ -30,7 +30,7 @@ import {
   shouldKeepInactiveVideoPrewarmed,
   shouldMuteNativeMediaElement,
   shouldPrimeFutureInactiveVideoInPreview,
-  shouldRecoverAndroidPreviewVideoPlayback,
+  getAndroidPreviewRecoveryDecision,
   shouldRecoverAudioOnlyAfterVideoBoundary,
   shouldReinitializeAudioRoute,
   shouldRetryAudioOnlyPrimeAtPreviewStart,
@@ -376,6 +376,14 @@ export function usePreviewEngine({
   logWarn,
   logDebug,
 }: UsePreviewEngineParams): UsePreviewEngineResult {
+  const androidPreviewRecoveryRef = useRef<Record<string, {
+    active: boolean;
+    reason: string;
+    startedAt: number;
+    lastAttemptAt: number;
+    lastTargetTime: number;
+    attempts: number;
+  }>>({});
   const handleMediaElementLoaded = useCallback(
     (id: string, element: HTMLVideoElement | HTMLImageElement | HTMLAudioElement) => {
       if (element.tagName === 'VIDEO') {
@@ -919,27 +927,56 @@ export function usePreviewEngine({
                   });
                 }
 
-                const shouldRecoverAndroidPlayback = shouldRecoverAndroidPreviewVideoPlayback({
+                const androidRecoveryDecision = getAndroidPreviewRecoveryDecision({
                   isAndroid: platformCapabilities.isAndroid,
+                  isIosSafari: platformCapabilities.isIosSafari,
                   isExporting: _isExporting,
                   isActivePlaying,
                   isUserSeeking,
                   videoPaused: videoEl.paused,
                   videoSeeking: isVideoSeeking,
                   videoReadyState: videoEl.readyState,
+                  videoWidth: videoEl.videoWidth,
+                  videoHeight: videoEl.videoHeight,
+                  videoCurrentTime: videoEl.currentTime,
+                  targetTime,
                 });
-                if (shouldRecoverAndroidPlayback) {
-                  const now = Date.now();
+                if (androidRecoveryDecision.shouldRecover) {
+                  const now = getStandardPreviewNow();
                   const lastAttempt = videoRecoveryAttemptsRef.current[id] || 0;
+                  holdFrame = holdFrame || androidRecoveryDecision.shouldHoldFrame;
                   if (now - lastAttempt > 220) {
                     videoRecoveryAttemptsRef.current[id] = now;
+                    const recoveryState = androidPreviewRecoveryRef.current[id] ?? {
+                      active: true,
+                      reason: androidRecoveryDecision.reason ?? 'ready-state-low',
+                      startedAt: now,
+                      lastAttemptAt: 0,
+                      lastTargetTime: targetTime,
+                      attempts: 0,
+                    };
+                    recoveryState.attempts += 1;
+                    recoveryState.lastAttemptAt = now;
+                    recoveryState.lastTargetTime = targetTime;
+                    androidPreviewRecoveryRef.current[id] = recoveryState;
                     if (videoEl.readyState === 0 && !videoEl.error) {
                       try { videoEl.load(); } catch { /* ignore */ }
                     }
-                    if (!isVideoSeeking && videoEl.readyState >= MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME) {
+                    if (androidRecoveryDecision.shouldResyncTime && !videoEl.seeking && videoEl.readyState >= 1) {
+                      videoEl.currentTime = targetTime;
+                    }
+                    if (
+                      androidRecoveryDecision.shouldRetryPlay
+                      && !isVideoSeeking
+                      && videoEl.readyState >= MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME
+                    ) {
                       videoEl.play().catch(() => { /* ignore */ });
                     }
                   }
+                } else if (androidPreviewRecoveryRef.current[id]) {
+                  delete androidPreviewRecoveryRef.current[id];
+                  startTimeRef.current = getStandardPreviewNow() - currentTimeRef.current * 1000;
+                  primePreviewAudioOnlyTracksAtTimeRef.current(currentTimeRef.current);
                 }
               } else if (!isActivePlaying && !isUserSeeking) {
                 if (!videoEl.paused) {

--- a/src/flavors/standard/preview/usePreviewEngine.ts
+++ b/src/flavors/standard/preview/usePreviewEngine.ts
@@ -942,7 +942,7 @@ export function usePreviewEngine({
                   targetTime,
                 });
                 if (androidRecoveryDecision.shouldRecover) {
-                  const now = getStandardPreviewNow();
+                  const now = Date.now();
                   const lastAttempt = videoRecoveryAttemptsRef.current[id] || 0;
                   holdFrame = holdFrame || androidRecoveryDecision.shouldHoldFrame;
                   if (now - lastAttempt > 220) {

--- a/src/test/previewPlatform.test.ts
+++ b/src/test/previewPlatform.test.ts
@@ -25,6 +25,7 @@ import {
   shouldStabilizeImageToVideoTransitionDuringExport,
   shouldUseCaptionBlurFallback,
 } from '../utils/previewPlatform';
+import { getAndroidPreviewRecoveryDecision } from '../flavors/standard/preview/previewPlatform';
 
 describe('getPreviewPlatformPolicy', () => {
   it('iOS Safari では preview/export 向けの緩和値を返す', () => {
@@ -762,6 +763,31 @@ describe('preview platform helpers', () => {
         videoReadyState: 2,
       }),
     ).toBe(false);
+  });
+
+  it('Android recovery decision helper は paused/seeking/readyState不足/dimension/drift を判定する', () => {
+    expect(getAndroidPreviewRecoveryDecision({
+      isAndroid: true, isIosSafari: false, isExporting: false, isActivePlaying: true, isUserSeeking: false,
+      videoPaused: true, videoSeeking: false, videoReadyState: 4, videoWidth: 1920, videoHeight: 1080, videoCurrentTime: 1, targetTime: 1,
+    }).reason).toBe('paused-during-playback');
+    expect(getAndroidPreviewRecoveryDecision({
+      isAndroid: true, isIosSafari: false, isExporting: false, isActivePlaying: true, isUserSeeking: false,
+      videoPaused: false, videoSeeking: true, videoReadyState: 4, videoWidth: 1920, videoHeight: 1080, videoCurrentTime: 1, targetTime: 1,
+    }).reason).toBe('seeking-during-playback');
+    expect(getAndroidPreviewRecoveryDecision({
+      isAndroid: true, isIosSafari: false, isExporting: false, isActivePlaying: true, isUserSeeking: false,
+      videoPaused: false, videoSeeking: false, videoReadyState: 1, videoWidth: 1920, videoHeight: 1080, videoCurrentTime: 1, targetTime: 1,
+    }).reason).toBe('ready-state-low');
+    expect(getAndroidPreviewRecoveryDecision({
+      isAndroid: true, isIosSafari: false, isExporting: false, isActivePlaying: true, isUserSeeking: false,
+      videoPaused: false, videoSeeking: false, videoReadyState: 4, videoWidth: 0, videoHeight: 1080, videoCurrentTime: 1, targetTime: 1,
+    }).reason).toBe('dimension-zero');
+    const drift = getAndroidPreviewRecoveryDecision({
+      isAndroid: true, isIosSafari: false, isExporting: false, isActivePlaying: true, isUserSeeking: false,
+      videoPaused: false, videoSeeking: false, videoReadyState: 4, videoWidth: 1920, videoHeight: 1080, videoCurrentTime: 2, targetTime: 1,
+    });
+    expect(drift.reason).toBe('timeline-drift');
+    expect(drift.shouldHoldFrame).toBe(true);
   });
 
   it('iOS Safari preview は単一動画だけ native 出力を維持し、動画+BGM では WebAudio mix に寄せる', () => {


### PR DESCRIPTION
### Motivation
- Prevent multi-second blackouts in Android standard preview by detecting transient video decode/playback issues and holding the last good frame while recovery proceeds.
- Keep Android-specific recovery logic confined to the `standard` preview runtime so iOS Safari behavior is not affected.

### Description
- Add types and a new decision helper `getAndroidPreviewRecoveryDecision` with `AndroidPreviewRecoveryDecisionOptions`/`AndroidPreviewRecoveryDecision` and reasons such as `paused-during-playback`, `seeking-during-playback`, `ready-state-low`, `dimension-zero`, and `timeline-drift` in `src/flavors/standard/preview/previewPlatform.ts` and make `shouldRecoverAndroidPreviewVideoPlayback` delegate to it.
- Integrate the decision helper into `usePreviewEngine` by adding `androidPreviewRecoveryRef` and using the helper to enforce `holdFrame`, attempt `load()` retry, optionally resync `currentTime`, retry `play()` under controlled conditions, track recovery attempts, and on recovery clear recovery state, rebase `startTimeRef` via `getStandardPreviewNow()` and call `primePreviewAudioOnlyTracksAtTimeRef` to re-sync audio-only tracks.
- Keep the Android logic inside `src/flavors/standard/preview/**` and do not modify `apple-safari` runtime behavior.
- Add unit tests for the new decision helper cases (paused, seeking, readyState low, dimension zero, timeline drift) in `src/test/previewPlatform.test.ts`.

### Testing
- Ran `npm run typecheck` and it passed without errors.
- Ran `npm run test:run` and all tests passed (`322 tests` across the suite passed).
- Ran `npm run build` and the production build completed successfully.
- Ran `npm run quality:gate` which executed unit tests, lint, and build and reported a PASS (lint produced existing warnings but no errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1e1166c748325b04a738ca5239133)