### PR TITLE
fix: export完了後のURL受け渡しとタイムアウト競合を修正

### DIFF
--- a/src/components/TurtleVideo.tsx
+++ b/src/components/TurtleVideo.tsx
@@ -239,6 +239,7 @@ const TurtleVideo: React.FC<TurtleVideoProps> = ({ appFlavor, previewRuntime, ex
   const pendingSeekRef = useRef<number | null>(null); // 保留中のシーク位置
   const wasPlayingBeforeSeekRef = useRef(false); // シーク前の再生状態を保持
   const wasExportProcessingRef = useRef(isProcessing);
+  const exportCompletedRef = useRef(false);
   const pendingSeekTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null); // 保留中のシーク処理用タイマー
 
 
@@ -415,6 +416,9 @@ const TurtleVideo: React.FC<TurtleVideoProps> = ({ appFlavor, previewRuntime, ex
     wasExportProcessingRef.current = isProcessing;
 
     if (exportUrl || (wasProcessing && !isProcessing)) {
+      if (exportUrl) {
+        exportCompletedRef.current = true;
+      }
       clearExportUiState();
     }
   }, [clearExportUiState, exportUrl, isProcessing]);
@@ -1719,11 +1723,12 @@ const TurtleVideo: React.FC<TurtleVideoProps> = ({ appFlavor, previewRuntime, ex
   // --- エクスポート開始ハンドラ ---
   // 目的: 動画ファイルとして書き出しを開始
   const handleExport = useCallback(() => {
+    exportCompletedRef.current = false;
     startEngine(0, true);
   }, [startEngine]);
 
   const handleExportFinalizeTimeout = useCallback(() => {
-    if (!isProcessing || exportUrl) return;
+    if (!isProcessing || exportUrl || exportCompletedRef.current) return;
     stopWebCodecsExport({ silent: true });
     clearExportUiState();
     pause();

--- a/src/components/turtle-video/usePreviewEngine.ts
+++ b/src/components/turtle-video/usePreviewEngine.ts
@@ -2110,12 +2110,16 @@ export function usePreviewEngine({
           canvasRef,
           masterDestRef,
           (url, ext) => {
+            logInfo('RENDER', '[DIAG-UI] export complete callback received', {
+              urlPresent: Boolean(url),
+              ext,
+            });
             setExportUrl(url);
             setExportExt(ext as 'mp4' | 'webm');
             setProcessing(false);
+            setLoading(false);
             setExportPreparationStep(null);
             pause();
-            stopAll();
           },
           (message) => {
             setProcessing(false);

--- a/src/hooks/useExport.ts
+++ b/src/hooks/useExport.ts
@@ -2408,8 +2408,8 @@ export function createUseExport(config: UseExportRuntimeConfig) {
           (err as any)?.name === 'AbortError' ||
           (err as any)?.message?.includes('Aborted');
 
-        if (exportCompletedRef.current && !hasNotifiedRecordingStop) {
-          logError('export completed but callback was not delivered');
+        if (!hasNotifiedRecordingStop) {
+          logError('recording stop callback was not delivered before export finalization failed');
         }
 
         if (!isAbort) {

--- a/src/hooks/useExport.ts
+++ b/src/hooks/useExport.ts
@@ -1032,6 +1032,9 @@ export function createUseExport(config: UseExportRuntimeConfig) {
     const audioReaderRef = useRef<ReadableStreamDefaultReader<AudioData> | null>(null);
     const completionRequestedRef = useRef(false);
     const silentAbortRef = useRef(false);
+    const finalizeRequestedRef = useRef(false);
+    const userCancelledExportRef = useRef(false);
+    const exportCompletedRef = useRef(false);
 
     // 互換性維持のためのダミーRef（実際には使用しない）
     const recorderRef = useRef<MediaRecorder | null>(null);
@@ -1046,6 +1049,8 @@ export function createUseExport(config: UseExportRuntimeConfig) {
   const stopExport = useCallback((options?: { silent?: boolean }) => {
     useLogStore.getState().info('RENDER', 'エクスポートを停止');
     completionRequestedRef.current = false;
+    finalizeRequestedRef.current = false;
+    userCancelledExportRef.current = true;
     silentAbortRef.current = options?.silent === true;
     if (abortControllerRef.current) {
       abortControllerRef.current.abort();
@@ -1067,6 +1072,8 @@ export function createUseExport(config: UseExportRuntimeConfig) {
   const completeExport = useCallback(() => {
     useLogStore.getState().info('RENDER', 'エクスポートの正常終了を要求');
     completionRequestedRef.current = true;
+    finalizeRequestedRef.current = true;
+    userCancelledExportRef.current = false;
     if (videoReaderRef.current) {
       videoReaderRef.current.cancel().catch(() => { });
       videoReaderRef.current = null;
@@ -1118,6 +1125,9 @@ export function createUseExport(config: UseExportRuntimeConfig) {
       });
       setExportExt(null);
       completionRequestedRef.current = false;
+      finalizeRequestedRef.current = false;
+      userCancelledExportRef.current = false;
+      exportCompletedRef.current = false;
       silentAbortRef.current = false;
       updatePreparationStep(audioSources, 1);
       const audioDecodeCache = new Map<string, Promise<AudioBuffer | null>>();
@@ -2347,7 +2357,7 @@ export function createUseExport(config: UseExportRuntimeConfig) {
 
         if (buffer.byteLength > 0) {
           const blob = new Blob([buffer], { type: 'video/mp4' });
-          if (blob.size === 0) {
+          if (blob.size <= 0) {
             throw new Error('書き出し結果が空です');
           }
           let url: string;
@@ -2375,7 +2385,12 @@ export function createUseExport(config: UseExportRuntimeConfig) {
             audioDataPresent: audioEncoderOutputChunks > 0,
             offlineAudioDone,
           });
+          logInfo('[DIAG-10] export URL 作成完了', {
+            blobSize: blob.size,
+            urlCreated: Boolean(url),
+          });
           try {
+            exportCompletedRef.current = true;
             notifyRecordingStop(url, 'mp4');
             setExportUrl(url);
             setExportExt('mp4');
@@ -2393,6 +2408,10 @@ export function createUseExport(config: UseExportRuntimeConfig) {
           (err as any)?.name === 'AbortError' ||
           (err as any)?.message?.includes('Aborted');
 
+        if (exportCompletedRef.current && !hasNotifiedRecordingStop) {
+          logError('export completed but callback was not delivered');
+        }
+
         if (!isAbort) {
           logError('export finalize failed', {
             error: err instanceof Error ? err.message : String(err)
@@ -2401,11 +2420,15 @@ export function createUseExport(config: UseExportRuntimeConfig) {
           onRecordingError?.(
             err instanceof Error ? err.message : '動画ファイルの作成に失敗しました'
           );
-        } else {
+        } else if (userCancelledExportRef.current) {
           logInfo('エクスポートが中断されました');
           if (!silentAbortRef.current) {
             onRecordingError?.('エクスポートが中断されました');
           }
+        } else if (finalizeRequestedRef.current || completionRequestedRef.current) {
+          logInfo('正常終了要求後の中断を検出しましたが、完了処理を優先します');
+        } else {
+          logInfo('エクスポートが中断されました');
         }
       } finally {
         if (canvasFramePumpTimer) {
@@ -2428,6 +2451,8 @@ export function createUseExport(config: UseExportRuntimeConfig) {
         audioReaderRef.current = null;
         recorderRef.current = null;
         completionRequestedRef.current = false;
+        finalizeRequestedRef.current = false;
+        userCancelledExportRef.current = false;
         silentAbortRef.current = false;
         setIsProcessing(false);
       }


### PR DESCRIPTION
### Motivation
- エンコード自体は成功しているのに UI に `exportUrl` が渡らずダウンロードボタンが表示されない問題を解消するため。
- 完了ログ（DIAG-9）後に約30秒で発生する `export finalize timeout` は、完了済み経路と timeout が競合していることが原因のため防止したい。
- 自然終端（正常完了）とユーザーキャンセルの扱いを分離して、完了コールバックが潰されないようにする。 

### Description
- `src/hooks/useExport.ts` に `finalizeRequestedRef` / `userCancelledExportRef` / `exportCompletedRef` を追加して自然終端とキャンセルを分離し、完了フラグを管理するようにした。 
- DIAG-9 の直後に Blob URL を作成した旨の `[DIAG-10] export URL 作成完了` を出力し、`exportCompletedRef` を立てた上で `onRecordingStop`（callback）を確実に呼ぶ経路を強化した。 
- 成功時の Blob サイズチェックを厳密化（`<= 0`）し、Blob 作成や `URL.createObjectURL` の失敗時に明確なエラーを投げるようにした。 
- abort/例外ハンドリングで「完了済みだが callback 未通知」のケースをログ出力し、ユーザーキャンセル由来か正常終了要求由来かで挙動を分岐するようにした。 
- `src/components/turtle-video/usePreviewEngine.ts` のエクスポート成功コールバックに診断ログ `[DIAG-UI] export complete callback received` を追加し、受信時に `setExportUrl`/`setExportExt`/`setProcessing(false)`/`setLoading(false)`/`setExportPreparationStep(null)` を必ず実行するように調整した（成功後に `stopAll()` を呼ばない）。 
- `src/components/TurtleVideo.tsx` に `exportCompletedRef` を追加して export 開始時に初期化し、finalize timeout ハンドラで完了済みなら timeout を無視するガードを追加した。 
- 変更対象ファイル: `src/hooks/useExport.ts`, `src/components/TurtleVideo.tsx`, `src/components/turtle-video/usePreviewEngine.ts`。 

### Testing
- 型チェックを `npm run typecheck` で実行して成功（`tsc --noEmit` 実行済み）。
- 単体テストを `npm run test:run` で実行し、テスト結果は `49 files` / `355 tests` 全て通過（すべて成功）。
- ビルドを `npm run build` で実行して成功し、プロダクションビルドが生成された。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3c68b744083258dc910f810bf0cd4)