### PR TITLE
useExport テストの resolver 型修正でビルド失敗を解消

### DIFF
--- a/.github/skills/turtle-video-overview/references/implementation-patterns.md
+++ b/.github/skills/turtle-video-overview/references/implementation-patterns.md
@@ -1939,3 +1939,13 @@
 - **注意**:
   - Android 判定は shared UI 側で直接増やさず、runtime から渡された capability をもとに `TurtleVideo.tsx` 側で経路を決める。
   - `capture` は付けず、OS / Chrome / 端末設定によって picker 表示が変わる前提で「サムネイル一覧が出やすい経路」を優先する。
+
+### 13-74. Promise の resolve ハンドラ保持は `null` より `undefined + 明示型` で固定する
+
+- **対象ファイル**: `src/test/useExport.test.ts`
+- **問題**:
+  - Vitest の `mockImplementation` 内で `new Promise<boolean>((resolve) => ...)` の `resolve` を外側変数へ退避する際、`null` union のまま扱うと TypeScript の制御フロー解析で呼び出し地点が `never` 扱いになり、`This expression is not callable` を起こすことがある。
+- **対応パターン**:
+  - 退避変数を `((handled: boolean) => void) | undefined` とし、利用前ガード後に `const strategyResolver: (handled: boolean) => void = resolveStrategy` のように明示型で受ける。
+- **注意**:
+  - Promise の `resolve` は `boolean | PromiseLike<boolean>` を受けられるため、テスト意図が boolean 解決で固定されている場合は受け側関数型を明示しておく。

--- a/src/test/useExport.test.ts
+++ b/src/test/useExport.test.ts
@@ -387,7 +387,7 @@ describe('useExport', () => {
     );
 
     let capturedSignal: AbortSignal | null = null;
-    let resolveStrategy: ((handled: boolean) => void) | null = null;
+    let resolveStrategy: ((handled: boolean) => void) | undefined;
     mockRunIosSafariMediaRecorderStrategy.mockImplementation(
       ({ signal }: { signal: AbortSignal }) =>
         new Promise<boolean>((resolve) => {
@@ -432,7 +432,7 @@ describe('useExport', () => {
       throw new Error('Strategy resolver was not captured');
     }
     const signal = capturedSignal as AbortSignal;
-    const strategyResolver = resolveStrategy;
+    const strategyResolver: (handled: boolean) => void = resolveStrategy;
     expect(signal.aborted).toBe(false);
     expect(args.onRecordingError).not.toHaveBeenCalled();
 


### PR DESCRIPTION
### Motivation
- `npm run build` が `TS2349: This expression is not callable` で失敗しており、`useExport` テスト内で Promise の `resolve` を外側変数へ退避する際の型扱いが原因と判明したため修正しました。

### Description
- `src/test/useExport.test.ts` で `resolveStrategy` を `((handled: boolean) => void) | undefined` に変更し、使用前に `const strategyResolver: (handled: boolean) => void = resolveStrategy;` と明示的な関数型で束縛するようにして `strategyResolver(true)` 呼び出し時の型エラーを解消しました。
- 再発防止のために今回の型付け注意点を `.github/skills/turtle-video-overview/references/implementation-patterns.md` に追記しました。

### Testing
- `npm run build` を実行し、TypeScript コンパイルと `vite build` が正常に完了することを確認しました（ビルド成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f443371ecc8325a4a31bb33dfe3ff7)