### PR TITLE
fix: TypeScriptビルドを阻害していた未使用変数をテストから削除

### DIFF
--- a/src/test/standardPreviewEngine.test.tsx
+++ b/src/test/standardPreviewEngine.test.tsx
@@ -836,7 +836,6 @@ describe('standard preview engine', () => {
     });
 
     const timelineTime = 1.1;
-    const expectedTime = videoItem.trimStart + (timelineTime - imageItem.duration);
     const didUpdateCanvas = hook.result.current.renderFrame(timelineTime, true, false);
 
     expect(videoElement.currentTime).toBeCloseTo(1.36);
@@ -1214,7 +1213,6 @@ describe('standard preview engine', () => {
     });
 
     const insideTimelineTime = 1.25;
-    const insideExpectedTime = videoItem.trimStart + (insideTimelineTime - imageItem.duration);
     insideHarness.hook.result.current.renderFrame(insideTimelineTime, true, false);
 
     expect(insideWindowVideo.currentTime).toBeCloseTo(1.6);


### PR DESCRIPTION
### Motivation
- `npm run build` が `TS6133`（未使用変数）で失敗していたため CI のビルドを通す目的で修正しました。

### Description
- `src/test/standardPreviewEngine.test.tsx` から未使用の変数 `expectedTime` と `insideExpectedTime` を削除し、テストのアサーションや挙動は変更していません。

### Testing
- `npm run build`（`tsc` と `vite build` を含む）を実行してビルドが成功することを確認しました.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4735d31c48325849f26daef51af2a)