### PR TITLE
Align export caption timing to encoded frame timestamps

### DIFF
--- a/.github/skills/turtle-video-overview/references/implementation-patterns.md
+++ b/.github/skills/turtle-video-overview/references/implementation-patterns.md
@@ -1983,3 +1983,16 @@
   - 退避変数を `((handled: boolean) => void) | undefined` とし、利用前ガード後に `const strategyResolver: (handled: boolean) => void = resolveStrategy` のように明示型で受ける。
 - **注意**:
   - Promise の `resolve` は `boolean | PromiseLike<boolean>` を受けられるため、テスト意図が boolean 解決で固定されている場合は受け側関数型を明示しておく。
+
+### 13-75. export 時の caption 判定時刻は「エンコード対象フレーム timestamp」に固定する
+
+- **対象ファイル**: `src/flavors/standard/preview/usePreviewEngine.ts`, `src/flavors/apple-safari/preview/usePreviewEngine.ts`, `src/utils/captionTimeline.ts`, `src/test/exportTimeline.test.ts`
+- **問題**:
+  - export ループが壁時計由来の `elapsed` をそのまま caption 判定へ流すと、エンコーダーへ渡す `VideoFrame.timestamp` と表示判定時刻が一致せず、字幕だけ 0.1〜0.3 秒遅れて見えることがある。
+- **対応パターン**:
+  - standard export の `renderFrame()` には `getExportFrameTiming(resolveExportDuration(...), FPS, frameIndex)` から算出した `timestampUs / 1e6` を渡し、Canvas 描画時刻を encoded timestamp と一致させる。
+  - caption の表示判定は `isCaptionActiveAtTime()` helper に統一し、preview / export の双方で同じ `[start, end)` 判定を使う。
+  - export 診断ログ `[DIAG-CAPTION-EXPORT-TIMING]` では frame timestamp・caption 境界・isActive を同一レコードへ出力し、時刻基準の不一致を早期検出する。
+- **注意**:
+  - caption 用の固定オフセット補正（±0.2s など）は導入しない。素材依存で逆効果になるため、まず timestamp 基準の一致を優先する。
+  - iOS Safari export 経路は既存戦略を維持し、今回の時刻固定は standard runtime の export ループへ限定する。

--- a/src/flavors/apple-safari/preview/usePreviewEngine.ts
+++ b/src/flavors/apple-safari/preview/usePreviewEngine.ts
@@ -18,6 +18,7 @@ import type { LogCategory } from '../../../stores/logStore';
 import { useMediaStore } from '../../../stores';
 import type { PlatformCapabilities } from '../../../utils/platform';
 import { collectPlaybackBlockingVideos, findActiveTimelineItem } from '../../../utils/playbackTimeline';
+import { isCaptionActiveAtTime } from '../../../utils/captionTimeline';
 import {
   EXPORT_IMAGE_TO_VIDEO_STABILIZATION_SYNC_TOLERANCE_SEC,
   getPreviewAudioOutputMode,
@@ -993,7 +994,7 @@ export function usePreviewEngine({
         const currentCaptionSettings = captionSettingsRef.current;
         if (currentCaptionSettings.enabled && currentCaptions.length > 0) {
           const activeCaptions = currentCaptions.filter(
-            (c) => time >= c.startTime && time < c.endTime,
+            (c) => isCaptionActiveAtTime(c, time),
           );
           for (const activeCaption of activeCaptions) {
             const fontSizeMap = { small: 32, medium: 48, large: 64, xlarge: 80 };

--- a/src/flavors/standard/preview/usePreviewEngine.ts
+++ b/src/flavors/standard/preview/usePreviewEngine.ts
@@ -18,6 +18,8 @@ import type { LogCategory } from '../../../stores/logStore';
 import { useMediaStore } from '../../../stores';
 import type { PlatformCapabilities } from '../../../utils/platform';
 import { collectPlaybackBlockingVideos, findActiveTimelineItem } from '../../../utils/playbackTimeline';
+import { isCaptionActiveAtTime } from '../../../utils/captionTimeline';
+import { getExportFrameTiming, resolveExportDuration } from '../../../utils/exportTimeline';
 import {
   ANDROID_PREVIEW_DRIFT_FIX_THRESHOLD_SEC,
   EXPORT_IMAGE_TO_VIDEO_STABILIZATION_SYNC_TOLERANCE_SEC,
@@ -1474,11 +1476,29 @@ export function usePreviewEngine({
 
         const currentCaptions = captionsRef.current;
         const currentCaptionSettings = captionSettingsRef.current;
+        const exportFrameIndex = _isExporting ? Math.max(0, Math.floor(time * FPS + 1e-9)) : null;
+        const exportDurationAlignment = _isExporting
+          ? resolveExportDuration(totalDurationRef.current, FPS)
+          : null;
+        const exportFrameTiming = (_isExporting && exportDurationAlignment && exportFrameIndex !== null && exportFrameIndex < exportDurationAlignment.frameCount)
+          ? getExportFrameTiming(exportDurationAlignment, FPS, exportFrameIndex)
+          : null;
         if (currentCaptionSettings.enabled && currentCaptions.length > 0) {
           const activeCaptions = currentCaptions.filter(
-            (c) => time >= c.startTime && time < c.endTime,
+            (c) => isCaptionActiveAtTime(c, time),
           );
           for (const activeCaption of activeCaptions) {
+            if (_isExporting && exportFrameTiming && time <= 3) {
+              logInfo('RENDER', '[DIAG-CAPTION-EXPORT-TIMING]', {
+                frameIndex: exportFrameIndex,
+                frameTimestampUs: exportFrameTiming.timestampUs,
+                exportFrameTimeSec: time,
+                captionId: activeCaption.id,
+                captionStart: activeCaption.startTime,
+                captionEnd: activeCaption.endTime,
+                isActive: isCaptionActiveAtTime(activeCaption, time),
+              });
+            }
             const fontSizeMap = { small: 32, medium: 48, large: 64, xlarge: 80 };
             const effectiveFontSizeKey = activeCaption.overrideFontSize ?? currentCaptionSettings.fontSize;
             const fontSize = fontSizeMap[effectiveFontSizeKey];
@@ -2138,9 +2158,17 @@ export function usePreviewEngine({
         }
         return;
       }
-      setCurrentTime(clampedElapsed);
-      currentTimeRef.current = clampedElapsed;
-      renderFrame(clampedElapsed, true, isExportMode);
+      const exportDurationAlignment = isExportMode ? resolveExportDuration(totalDuration, FPS) : null;
+      const exportFrameIndex = isExportMode && exportDurationAlignment !== null && exportDurationAlignment.frameCount > 0
+        ? Math.min(exportDurationAlignment.frameCount - 1, Math.max(0, Math.floor(clampedElapsed * FPS + 1e-9)))
+        : null;
+      const exportFrameTiming = isExportMode && exportDurationAlignment && exportFrameIndex !== null
+        ? getExportFrameTiming(exportDurationAlignment, FPS, exportFrameIndex)
+        : null;
+      const renderTimeSec = exportFrameTiming ? (exportFrameTiming.timestampUs / 1e6) : clampedElapsed;
+      setCurrentTime(renderTimeSec);
+      currentTimeRef.current = renderTimeSec;
+      renderFrame(renderTimeSec, true, isExportMode);
       reqIdRef.current = requestAnimationFrame(() => loop(isExportMode, myLoopId));
     },
     [

--- a/src/test/exportTimeline.test.ts
+++ b/src/test/exportTimeline.test.ts
@@ -7,6 +7,8 @@ import {
   resolveExportPlaybackTimeSec,
   resolveExportDuration,
 } from '../utils/exportTimeline';
+import { isCaptionActiveAtTime } from '../utils/captionTimeline';
+import type { Caption } from '../types';
 
 describe('resolveExportDuration', () => {
   it('raw timeline duration を exportDuration として一本化する', () => {
@@ -152,5 +154,51 @@ describe('resolveExportCanvasFrameBurstCount', () => {
         pendingFrameCount: Number.NaN,
       }),
     ).toBe(0);
+  });
+});
+
+describe('isCaptionActiveAtTime', () => {
+  const caption: Caption = {
+    id: 'cap-1',
+    text: 'caption',
+    startTime: 1.0,
+    endTime: 2.0,
+    fadeIn: false,
+    fadeOut: false,
+    fadeInDuration: 0.5,
+    fadeOutDuration: 0.5,
+  };
+
+  it('caption の開始を含み終了を含まない区間判定を行う', () => {
+    expect(isCaptionActiveAtTime(caption, 0.999)).toBe(false);
+    expect(isCaptionActiveAtTime(caption, 1.000)).toBe(true);
+    expect(isCaptionActiveAtTime(caption, 1.033)).toBe(true);
+    expect(isCaptionActiveAtTime(caption, 1.999)).toBe(true);
+    expect(isCaptionActiveAtTime(caption, 2.000)).toBe(false);
+  });
+
+  it('export frame timestamp 由来の時刻でも同じ判定になる', () => {
+    const alignment = resolveExportDuration(3, 30);
+
+    const before = getExportFrameTiming(alignment, 30, 29).timestampUs / 1e6;
+    const firstActiveFrameIndex = Array.from({ length: alignment.frameCount }).findIndex((_, frameIndex) => {
+      const timeSec = getExportFrameTiming(alignment, 30, frameIndex).timestampUs / 1e6;
+      return isCaptionActiveAtTime(caption, timeSec);
+    });
+    const firstInactiveAfterActiveFrameIndex = Array.from({ length: alignment.frameCount }).findIndex((_, frameIndex) => {
+      if (frameIndex <= firstActiveFrameIndex) return false;
+      const timeSec = getExportFrameTiming(alignment, 30, frameIndex).timestampUs / 1e6;
+      return !isCaptionActiveAtTime(caption, timeSec);
+    });
+
+    const atStart = getExportFrameTiming(alignment, 30, firstActiveFrameIndex).timestampUs / 1e6;
+    const nearEnd = getExportFrameTiming(alignment, 30, firstInactiveAfterActiveFrameIndex - 1).timestampUs / 1e6;
+    const atEnd = getExportFrameTiming(alignment, 30, firstInactiveAfterActiveFrameIndex).timestampUs / 1e6;
+
+    expect(isCaptionActiveAtTime(caption, before)).toBe(false);
+    expect(firstActiveFrameIndex).toBeGreaterThan(0);
+    expect(isCaptionActiveAtTime(caption, atStart)).toBe(true);
+    expect(isCaptionActiveAtTime(caption, nearEnd)).toBe(true);
+    expect(isCaptionActiveAtTime(caption, atEnd)).toBe(false);
   });
 });

--- a/src/utils/captionTimeline.ts
+++ b/src/utils/captionTimeline.ts
@@ -1,0 +1,5 @@
+import type { Caption } from '../types';
+
+export function isCaptionActiveAtTime(caption: Caption, timeSec: number): boolean {
+  return timeSec >= caption.startTime && timeSec < caption.endTime;
+}


### PR DESCRIPTION
### Motivation

- Exports showed captions shifted by ~0.1–0.5s because Canvas draw times used wall-clock/playback time that could differ from the encoded `VideoFrame.timestamp` used by WebCodecs. 
- The goal is to make caption active checks use the same source-of-truth time as the encoded frame timestamps so preview timing and exported MP4 caption timing match.

### Description

- Add a small helper `isCaptionActiveAtTime` in `src/utils/captionTimeline.ts` and use it for caption active checks in preview/export code. 
- In `src/flavors/standard/preview/usePreviewEngine.ts` compute `getExportFrameTiming(...).timestampUs / 1e6` for export-mode frames and use that value as the `renderFrame` / `currentTimeRef` input so Canvas draw time equals encoded frame timestamp. 
- Use the same `isCaptionActiveAtTime` in `src/flavors/apple-safari/preview/usePreviewEngine.ts` to unify caption判定 logic across runtimes, and add a `[DIAG-CAPTION-EXPORT-TIMING]` diagnostic log (first few seconds of export) to correlate `frameTimestampUs`, caption boundaries and `isActive`. 
- Add tests in `src/test/exportTimeline.test.ts` to verify boundary behavior and that export-frame-derived timestamps produce the same caption active result, and update the implementation-patterns reference accordingly.

### Testing

- Ran the targeted unit tests with `npm run test:run -- src/test/exportTimeline.test.ts`, and all tests passed (18/18). 
- Built the project with `npm run build`, and the TypeScript compile + Vite build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4862c4878832585f17d1d5a801be9)