### PR TITLE
Androidプレビューの video -> video 境界での停止感を軽減

### DIFF
--- a/src/flavors/standard/preview/usePreviewEngine.ts
+++ b/src/flavors/standard/preview/usePreviewEngine.ts
@@ -464,7 +464,10 @@ export function usePreviewEngine({
     requestedAt: number;
     completed: boolean;
   }>>({});
-  const androidTrimEntryStateRef = useRef<Record<string, { didHardSeek: boolean }>>({});
+  const androidTrimEntryStateRef = useRef<Record<string, {
+    didHardSeek: boolean;
+    didRebaseClock: boolean;
+  }>>({});
   const logAndroidPreviewHold = useCallback(
     (videoId: string, timelineTime: number, activeEl?: HTMLVideoElement) => {
       const now = Date.now();
@@ -730,7 +733,6 @@ export function usePreviewEngine({
                 || activeEl.readyState < MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME
                 || activeEl.videoWidth <= 0
                 || activeEl.videoHeight <= 0
-                || activeEl.paused
               );
 
             if (!activeEl) {
@@ -746,7 +748,7 @@ export function usePreviewEngine({
               const targetTime = (activeItem.trimStart || 0) + localTime;
               const trimStart = activeItem.trimStart || 0;
               const entryState = androidTrimEntryStateRef.current[activeId]
-                ?? { didHardSeek: false };
+                ?? { didHardSeek: false, didRebaseClock: false };
               androidTrimEntryStateRef.current[activeId] = entryState;
               const holdAndroidPreviewFrame = () => {
                 holdFrame = true;
@@ -813,8 +815,22 @@ export function usePreviewEngine({
                   try { activeEl.load(); } catch { /* ignore */ }
                 }
               }
+              const isTrimmedEntry =
+                isAndroidPreviewPlayback
+                && activeItem.type === 'video'
+                && trimStart > 0.001
+                && localTime >= 0
+                && localTime <= PREVIEW_ANDROID_TRIMMED_VIDEO_HEAD_HOLD_WINDOW_SEC;
+              const preseekState = androidTrimPreseekRef.current[activeId];
+              const preseekDrift = Math.abs(activeEl.currentTime - targetTime);
+              const isPreseekReadyEntry =
+                !!preseekState?.completed
+                && activeEl.readyState >= MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME
+                && !activeEl.seeking
+                && preseekDrift <= 0.12;
               if (
                 shouldHoldTrimmedVideoHead
+                && !isPreseekReadyEntry
                 && (
                   activeEl.seeking
                   || activeEl.readyState < MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME
@@ -840,10 +856,18 @@ export function usePreviewEngine({
                     videoCurrentTime: activeEl.currentTime,
                   });
                 }
-                startTimeRef.current = getStandardPreviewNow() - currentTimeRef.current * 1000;
+                if (
+                  isTrimmedEntry
+                  && !entryState.didRebaseClock
+                  && (activeEl.seeking || activeEl.readyState < MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME)
+                ) {
+                  startTimeRef.current = getStandardPreviewNow() - currentTimeRef.current * 1000;
+                  entryState.didRebaseClock = true;
+                }
                 holdAndroidPreviewFrame();
-                logInfo('RENDER', '[DIAG-TRIM-HOLD] Android trimmed entry hold', {
+                logInfo('RENDER', '[DIAG-PREVIEW-BOUNDARY] Android trimmed entry hold', {
                   activeId,
+                  previousId: previousItem?.id ?? null,
                   trimStart,
                   localTime,
                   timelineTime: time,
@@ -854,6 +878,10 @@ export function usePreviewEngine({
                   paused: activeEl.paused,
                   seeking: activeEl.seeking,
                   didHardSeek: entryState.didHardSeek,
+                  didRebaseClock: entryState.didRebaseClock,
+                  holdFrame: true,
+                  preseekCompleted: !!preseekState?.completed,
+                  preseekDrift,
                 });
               }
               let didApplyAndroidPreviewDriftFix = false;
@@ -923,7 +951,18 @@ export function usePreviewEngine({
               }
               if (
                 isAndroidPreviewPlayback
-                && trimStart > 0.001
+                && activeEl.readyState >= MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME
+                && !activeEl.seeking
+                && activeEl.paused
+              ) {
+                requestVideoPlayWithRetry(activeEl, () =>
+                  isPlayingRef.current
+                  && !isSeekingRef.current
+                  && loopIdRef.current === currentLoopId,
+                );
+              }
+              if (
+                isTrimmedEntry
                 && activeEl.readyState >= MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME
                 && !activeEl.seeking
                 && activeEl.paused
@@ -934,11 +973,6 @@ export function usePreviewEngine({
                   localTime,
                   timelineTime: time,
                 });
-                requestVideoPlayWithRetry(activeEl, () =>
-                  isPlayingRef.current
-                  && !isSeekingRef.current
-                  && loopIdRef.current === currentLoopId,
-                );
               }
             }
           } else if (activeItem.type === 'image') {


### PR DESCRIPTION
### Motivation
- Android の standard preview で動画境界（video → video）に 0.2〜0.5 秒ほどの停止感が発生しているので、前回導入した trim 周りの安全待ちが通常境界にも広がらないように調整する。

### Description
- `src/flavors/standard/preview/usePreviewEngine.ts` の Android preview ロジックを修正し、`activeEl.paused` を描画不可判定から除外して paused のみで hold しないようにした。  
- trim 頭専用の処理を明確化し、entry 状態に `didRebaseClock` を追加して `startTimeRef` のリベースを trim entry かつ要件を満たす場合に最大1回に限定した。  
- preseek が完了しており ready/非 seeking かつ drift が小さい（<= 0.12s）trim 項目では hold をスキップする条件を追加した。  
- ready (`readyState >= 2`) かつ非 seeking の状態で paused の場合は hold ではなく `requestVideoPlayWithRetry` を投げて再生遷移を促すようにした。  
- 境界診断用ログとして `[DIAG-PREVIEW-BOUNDARY]` を追加し、`previousId`/`paused`/`seeking`/`drift`/`holdFrame`/`didHardSeek`/`didRebaseClock` 等を出力するようにした。  

### Testing
- 型チェックを実行して `tsc --noEmit`（`npm run typecheck`）が成功することを確認した。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f48abffb8c8325b5eec7d3eddb4237)