### PR TITLE
プレビュー境界診断ログとフレームギャップ計測を追加

### DIFF
--- a/src/flavors/standard/preview/usePreviewEngine.ts
+++ b/src/flavors/standard/preview/usePreviewEngine.ts
@@ -481,6 +481,13 @@ export function usePreviewEngine({
     activeId: null,
     bridgeFrameCount: 0,
   });
+  const previewTimelineDiagnosticsRef = useRef<{
+    lastRafNowMs: number | null;
+    lastSegmentIndex: number;
+  }>({
+    lastRafNowMs: null,
+    lastSegmentIndex: -1,
+  });
   const toDisplayTime = useCallback((globalTimeSec: number) => {
     const totalDuration = Math.max(0, totalDurationRef.current);
     if (totalDuration <= 0) return 0;
@@ -2331,6 +2338,8 @@ export function usePreviewEngine({
 
     setTimeout(() => {
       endFinalizedRef.current = false;
+      previewTimelineDiagnosticsRef.current.lastSegmentIndex = -1;
+      previewTimelineDiagnosticsRef.current.lastRafNowMs = null;
     }, 300);
   }, [
     activeVideoIdRef,
@@ -2395,6 +2404,17 @@ export function usePreviewEngine({
       }
 
       const now = getStandardPreviewNow();
+      const diagnostics = previewTimelineDiagnosticsRef.current;
+      if (diagnostics.lastRafNowMs !== null) {
+        const frameGapMs = now - diagnostics.lastRafNowMs;
+        if (frameGapMs >= 50) {
+          logWarn('RENDER', 'preview.frame.gap', {
+            frameGapMs: Math.round(frameGapMs * 100) / 100,
+            warningThresholdMs: 50,
+          });
+        }
+      }
+      diagnostics.lastRafNowMs = now;
       const elapsed = (now - startTimeRef.current) / 1000;
       const totalDuration = totalDurationRef.current;
       const clampedElapsed = Math.min(elapsed, totalDuration);
@@ -2429,6 +2449,42 @@ export function usePreviewEngine({
         : null;
       const globalTimeSec = exportFrameTiming ? (exportFrameTiming.timestampUs / 1e6) : clampedElapsed;
       const renderTimeSec = toDisplayTime(globalTimeSec);
+      const resolvedSegment = findActiveTimelineItem(mediaItemsRef.current, renderTimeSec, totalDuration);
+      const resolvedSegmentIndex = resolvedSegment?.index ?? -1;
+      const resolvedLocalTimeMs = resolvedSegment ? Math.round(resolvedSegment.localTime * 1000) : null;
+      logDebug('RENDER', 'preview.timeline.tick', {
+        globalTimeMs: Math.round(globalTimeSec * 1000),
+        displayGlobalTimeMs: Math.round(renderTimeSec * 1000),
+        totalDurationMs: Math.round(totalDuration * 1000),
+        segmentIndex: resolvedSegmentIndex,
+        localTimeMs: resolvedLocalTimeMs,
+      });
+      if (resolvedSegmentIndex !== diagnostics.lastSegmentIndex) {
+        if (diagnostics.lastSegmentIndex >= 0) {
+          logInfo('RENDER', 'preview.boundary.exit', {
+            globalTimeMs: Math.round(globalTimeSec * 1000),
+            displayGlobalTimeMs: Math.round(renderTimeSec * 1000),
+            totalDurationMs: Math.round(totalDuration * 1000),
+            boundaryIndex: diagnostics.lastSegmentIndex,
+          });
+        }
+        if (resolvedSegmentIndex >= 0) {
+          logInfo('RENDER', 'preview.boundary.enter', {
+            globalTimeMs: Math.round(globalTimeSec * 1000),
+            displayGlobalTimeMs: Math.round(renderTimeSec * 1000),
+            totalDurationMs: Math.round(totalDuration * 1000),
+            segmentIndex: resolvedSegmentIndex,
+            localTimeMs: resolvedLocalTimeMs,
+            boundaryIndex: resolvedSegmentIndex,
+          });
+        }
+        diagnostics.lastSegmentIndex = resolvedSegmentIndex;
+      }
+      logDebug('RENDER', 'preview.timeline.segmentResolved', {
+        globalTimeMs: Math.round(globalTimeSec * 1000),
+        segmentIndex: resolvedSegmentIndex,
+        localTimeMs: resolvedLocalTimeMs,
+      });
       setCurrentTime(globalTimeSec);
       currentTimeRef.current = globalTimeSec;
       renderFrame(renderTimeSec, true, isExportMode);


### PR DESCRIPTION
### Motivation
- プレビュー再生時の境界付近で発生する引っかかりや不具合の原因調査を容易にするため、再生ループでの時系列診断ログとフレームギャップ計測を追加する必要があった。 

### Description
- 再生エンジンに `previewTimelineDiagnosticsRef` を導入し、前回 rAF 時刻と前回セグメント index を保持する軽量な診断 state を追加した。 
- `getStandardPreviewNow()` を基点に rAF 間隔（frame gap）を計測し、50ms 以上を検出した場合に `preview.frame.gap` として警告ログを出力するようにした。 
- `globalTimeMs`（timeline ベース）から現在セグメントを解決して `preview.timeline.tick` / `preview.timeline.segmentResolved` を出力し、セグメント切替時に `preview.boundary.enter` / `preview.boundary.exit` を記録するロジックを追加した。 
- プレビュー完了時（`finalizePreviewAtTimelineEnd`）に診断参照をリセットする処理を追加し、次回再生への状態持ち越しを防止した。 

### Testing
- 型チェックを実行して `npm run typecheck` が成功することを確認した。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4af02e6f08325927722a5029eeb84)