### PR TITLE
プレビュー再生の毎フレームログを抑制し詳細診断モードを追加

### DIFF
--- a/src/flavors/standard/preview/usePreviewEngine.ts
+++ b/src/flavors/standard/preview/usePreviewEngine.ts
@@ -239,6 +239,22 @@ const PREVIEW_END_THRESHOLD_SEC = 0.03;
 const PREVIEW_START_READY_POLL_INTERVAL_MS = 40;
 const PREVIEW_START_READY_TIMEOUT_MS = 900;
 const DISPLAY_TIME_CLAMP_EPSILON_SEC = 0.001;
+const PREVIEW_DETAILED_TICK_LOG_INTERVAL_MS = 500;
+
+type PreviewLogMode = 'smooth' | 'detailed';
+
+const resolvePreviewLogMode = (): PreviewLogMode => {
+  if (typeof globalThis === 'undefined') {
+    return 'smooth';
+  }
+
+  const mode = globalThis.localStorage?.getItem('preview.log.mode');
+  if (mode === 'detailed') {
+    return 'detailed';
+  }
+
+  return 'smooth';
+};
 
 let previewExportSessionSequence = 0;
 
@@ -485,10 +501,15 @@ export function usePreviewEngine({
   const previewTimelineDiagnosticsRef = useRef<{
     lastRafNowMs: number | null;
     lastSegmentIndex: number;
+    lastTickLogAtMs: number | null;
+    lastShouldSuppressEndClear: boolean | null;
   }>({
     lastRafNowMs: null,
     lastSegmentIndex: -1,
+    lastTickLogAtMs: null,
+    lastShouldSuppressEndClear: null,
   });
+  const previewLogModeRef = useRef<PreviewLogMode>(resolvePreviewLogMode());
   const toDisplayTime = useCallback((globalTimeSec: number) => {
     const totalDuration = Math.max(0, totalDurationRef.current);
     if (totalDuration <= 0) return 0;
@@ -1245,27 +1266,33 @@ export function usePreviewEngine({
             && time < totalDurationRef.current
             && !hasExplicitFadeToBlack;
           if (shouldSuppressEndClear) {
-            logInfo('RENDER', 'preview.endClear.suppressed', {
-              globalTimeMs: Math.round(time * 1000),
-              totalDurationMs: Math.round(totalDurationRef.current * 1000),
-              isActivePlaying,
-              endFinalized: endFinalizedRef.current,
-              hasExplicitFadeToBlack,
-              shouldBlackoutFadeTail,
-              loopId: currentLoopId,
-              currentLoopId: loopIdRef.current,
-            });
+            if (previewTimelineDiagnosticsRef.current.lastShouldSuppressEndClear !== true) {
+              logInfo('RENDER', 'preview.endClear.suppressed', {
+                globalTimeMs: Math.round(time * 1000),
+                totalDurationMs: Math.round(totalDurationRef.current * 1000),
+                isActivePlaying,
+                endFinalized: endFinalizedRef.current,
+                hasExplicitFadeToBlack,
+                shouldBlackoutFadeTail,
+                loopId: currentLoopId,
+                currentLoopId: loopIdRef.current,
+              });
+            }
+            previewTimelineDiagnosticsRef.current.lastShouldSuppressEndClear = true;
           } else {
-            logInfo('RENDER', 'preview.endClear.executed', {
-              globalTimeMs: Math.round(time * 1000),
-              totalDurationMs: Math.round(totalDurationRef.current * 1000),
-              isActivePlaying,
-              endFinalized: endFinalizedRef.current,
-              hasExplicitFadeToBlack,
-              shouldBlackoutFadeTail,
-              loopId: currentLoopId,
-              currentLoopId: loopIdRef.current,
-            });
+            if (previewTimelineDiagnosticsRef.current.lastShouldSuppressEndClear !== false) {
+              logInfo('RENDER', 'preview.endClear.executed', {
+                globalTimeMs: Math.round(time * 1000),
+                totalDurationMs: Math.round(totalDurationRef.current * 1000),
+                isActivePlaying,
+                endFinalized: endFinalizedRef.current,
+                hasExplicitFadeToBlack,
+                shouldBlackoutFadeTail,
+                loopId: currentLoopId,
+                currentLoopId: loopIdRef.current,
+              });
+            }
+            previewTimelineDiagnosticsRef.current.lastShouldSuppressEndClear = false;
             ctx.globalAlpha = 1.0;
             ctx.fillStyle = '#000000';
             ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
@@ -2423,6 +2450,8 @@ export function usePreviewEngine({
       endFinalizedRef.current = false;
       previewTimelineDiagnosticsRef.current.lastSegmentIndex = -1;
       previewTimelineDiagnosticsRef.current.lastRafNowMs = null;
+      previewTimelineDiagnosticsRef.current.lastTickLogAtMs = null;
+      previewTimelineDiagnosticsRef.current.lastShouldSuppressEndClear = null;
     }, 300);
   }, [
     activeVideoIdRef,
@@ -2488,14 +2517,9 @@ export function usePreviewEngine({
 
       const now = getStandardPreviewNow();
       const diagnostics = previewTimelineDiagnosticsRef.current;
+      let frameGapMs: number | null = null;
       if (diagnostics.lastRafNowMs !== null) {
-        const frameGapMs = now - diagnostics.lastRafNowMs;
-        if (frameGapMs >= 50) {
-          logWarn('RENDER', 'preview.frame.gap', {
-            frameGapMs: Math.round(frameGapMs * 100) / 100,
-            warningThresholdMs: 50,
-          });
-        }
+        frameGapMs = now - diagnostics.lastRafNowMs;
       }
       diagnostics.lastRafNowMs = now;
       const elapsed = (now - startTimeRef.current) / 1000;
@@ -2535,14 +2559,39 @@ export function usePreviewEngine({
       const resolvedSegment = findActiveTimelineItem(mediaItemsRef.current, renderTimeSec, totalDuration);
       const resolvedSegmentIndex = resolvedSegment?.index ?? -1;
       const resolvedLocalTimeMs = resolvedSegment ? Math.round(resolvedSegment.localTime * 1000) : null;
-      logDebug('RENDER', 'preview.timeline.tick', {
-        globalTimeMs: Math.round(globalTimeSec * 1000),
-        displayGlobalTimeMs: Math.round(renderTimeSec * 1000),
-        totalDurationMs: Math.round(totalDuration * 1000),
-        segmentIndex: resolvedSegmentIndex,
-        localTimeMs: resolvedLocalTimeMs,
-      });
-      if (resolvedSegmentIndex !== diagnostics.lastSegmentIndex) {
+      const segmentChanged = resolvedSegmentIndex !== diagnostics.lastSegmentIndex;
+      if (frameGapMs !== null && frameGapMs >= 50) {
+        const activeVideoElement = resolvedSegment?.item?.type === 'video'
+          ? mediaElementsRef.current[resolvedSegment.item.id] as HTMLVideoElement | undefined
+          : undefined;
+        logWarn('RENDER', 'preview.frame.gap', {
+          frameGapMs: Math.round(frameGapMs * 100) / 100,
+          globalTimeMs: Math.round(globalTimeSec * 1000),
+          segmentIndex: resolvedSegmentIndex,
+          localTimeMs: resolvedLocalTimeMs,
+          readyState: activeVideoElement?.readyState,
+          paused: activeVideoElement?.paused,
+          seeking: activeVideoElement?.seeking,
+          holdFrame: activeVideoElement
+            ? (activeVideoElement.seeking || activeVideoElement.readyState < MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME)
+            : false,
+          warningThresholdMs: 50,
+        });
+      }
+      if (previewLogModeRef.current === 'detailed') {
+        const lastTickAt = diagnostics.lastTickLogAtMs ?? 0;
+        if (now - lastTickAt >= PREVIEW_DETAILED_TICK_LOG_INTERVAL_MS) {
+          logInfo('RENDER', 'preview.timeline.tick', {
+            globalTimeMs: Math.round(globalTimeSec * 1000),
+            displayGlobalTimeMs: Math.round(renderTimeSec * 1000),
+            totalDurationMs: Math.round(totalDuration * 1000),
+            segmentIndex: resolvedSegmentIndex,
+            localTimeMs: resolvedLocalTimeMs,
+          });
+          diagnostics.lastTickLogAtMs = now;
+        }
+      }
+      if (segmentChanged) {
         if (diagnostics.lastSegmentIndex >= 0) {
           logInfo('RENDER', 'preview.boundary.exit', {
             globalTimeMs: Math.round(globalTimeSec * 1000),
@@ -2563,11 +2612,13 @@ export function usePreviewEngine({
         }
         diagnostics.lastSegmentIndex = resolvedSegmentIndex;
       }
-      logDebug('RENDER', 'preview.timeline.segmentResolved', {
-        globalTimeMs: Math.round(globalTimeSec * 1000),
-        segmentIndex: resolvedSegmentIndex,
-        localTimeMs: resolvedLocalTimeMs,
-      });
+      if (previewLogModeRef.current === 'detailed' && segmentChanged) {
+        logInfo('RENDER', 'preview.timeline.segmentResolved', {
+          globalTimeMs: Math.round(globalTimeSec * 1000),
+          segmentIndex: resolvedSegmentIndex,
+          localTimeMs: resolvedLocalTimeMs,
+        });
+      }
       setCurrentTime(globalTimeSec);
       currentTimeRef.current = globalTimeSec;
       renderFrame(renderTimeSec, true, isExportMode);


### PR DESCRIPTION
### Motivation
- Android 実機のプレビュー再生中に毎フレーム大量のログ（`preview.timeline.tick` / `preview.timeline.segmentResolved` / `preview.endClear.suppressed` 等）が出力され、実機でのカクつき要因になっているため削減する目的です。
- 通常確認時は毎フレームの DEBUG/INFO 出力を止め、必要な場面のみ情報を残すことでパフォーマンス確認（smooth 検証）を容易にします。

### Description
- `src/flavors/standard/preview/usePreviewEngine.ts` にログモード（`preview.log.mode` を `localStorage` で指定）の導入と、既定値を `smooth` に設定しました。 (`PreviewLogMode`, `resolvePreviewLogMode`)
- 毎フレーム出力を止め、`preview.timeline.tick` は `detailed` モード時のみ最大500ms 間隔で出力するように変更しました（`smooth` では出力しない）。
- `preview.timeline.segmentResolved` はセグメントインデックスが変化したときにのみ `detailed` モードで出力するように変更しました。
- `preview.endClear.suppressed` / `preview.endClear.executed` は状態変化時のみ `logInfo` を出力するようにし、連続した毎フレーム出力を停止するために `lastShouldSuppressEndClear` を追加しました。
- フレームギャップ（rAF 差分）は従来どおり 50ms 超で `warning` を出し、警告時に `globalTimeMs` / `segmentIndex` / `localTimeMs` / `readyState` / `paused` / `seeking` / `holdFrame` 情報を追加で出力するように改善しました。
- ループ終了時の診断リセットに `lastTickLogAtMs` と `lastShouldSuppressEndClear` の初期化を追加しました。

### Testing
- `npm run -s lint` を実行しエラーは発生せず既存の警告のみが報告されました（エラー0、警告多数）。
- （自動テストの追加は行っておらず、変更はログ出力制御に限定されています。）

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4c2b0b2b48325a2714140a40e2eb6)