### PR TITLE
プレビューエンジンの TypeScript ビルドエラーを修正

### DIFF
--- a/src/flavors/standard/preview/usePreviewEngine.ts
+++ b/src/flavors/standard/preview/usePreviewEngine.ts
@@ -2561,8 +2561,11 @@ export function usePreviewEngine({
       const resolvedLocalTimeMs = resolvedSegment ? Math.round(resolvedSegment.localTime * 1000) : null;
       const segmentChanged = resolvedSegmentIndex !== diagnostics.lastSegmentIndex;
       if (frameGapMs !== null && frameGapMs >= 50) {
-        const activeVideoElement = resolvedSegment?.item?.type === 'video'
-          ? mediaElementsRef.current[resolvedSegment.item.id] as HTMLVideoElement | undefined
+        const resolvedMediaItem = resolvedSegmentIndex >= 0
+          ? mediaItemsRef.current[resolvedSegmentIndex]
+          : null;
+        const activeVideoElement = resolvedMediaItem?.type === 'video'
+          ? mediaElementsRef.current[resolvedMediaItem.id] as HTMLVideoElement | undefined
           : undefined;
         logWarn('RENDER', 'preview.frame.gap', {
           frameGapMs: Math.round(frameGapMs * 100) / 100,


### PR DESCRIPTION
### Motivation
- `usePreviewEngine` の診断ログ処理で `ActiveTimelineItem` に存在しない `item` プロパティを参照しており、`npm run build` が失敗していたため修正する。

### Description
- `resolvedSegment?.item` 参照を廃止して、`resolvedSegment.index` を元に `mediaItemsRef.current` から `resolvedMediaItem` を取得し、`resolvedMediaItem.type === 'video'` の場合にのみ `mediaElementsRef` から `HTMLVideoElement` を安全に参照するよう置き換えた（`src/flavors/standard/preview/usePreviewEngine.ts` の該当箇所を修正）。

### Testing
- `npm run build` を実行して TypeScript コンパイルと `vite build` が成功することを確認した。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f528f4427c8325bca5f404f95c5a18)