### PR TITLE
Android境界のpreseek準備条件を厳格化しログノイズを抑制

### DIFF
--- a/src/flavors/standard/preview/usePreviewEngine.ts
+++ b/src/flavors/standard/preview/usePreviewEngine.ts
@@ -498,6 +498,7 @@ export function usePreviewEngine({
     startLatencyLogged: boolean;
     boundaryEnterAtMs: number | null;
   }>>({});
+  const lastTrimmedEntryActiveIdRef = useRef<string | null>(null);
   const lastDrawableFrameRef = useRef<ImageBitmap | null>(null);
   const androidVisualBridgeStateRef = useRef<{ previousId: string | null; activeId: string | null; bridgeFrameCount: number; }>({
     previousId: null,
@@ -975,6 +976,10 @@ export function usePreviewEngine({
                 && trimStart > 0.001
                 && localTime >= 0
                 && localTime <= PREVIEW_ANDROID_TRIMMED_VIDEO_HEAD_HOLD_WINDOW_SEC;
+              if (lastTrimmedEntryActiveIdRef.current && lastTrimmedEntryActiveIdRef.current !== activeId) {
+                delete trimmedEntryLogStateRef.current[lastTrimmedEntryActiveIdRef.current];
+              }
+              lastTrimmedEntryActiveIdRef.current = activeId;
               const preseekState = androidTrimPreseekRef.current[activeId];
               const preseekDrift = Math.abs(activeEl.currentTime - targetTime);
               const trimmedDrift = Math.abs(activeEl.currentTime - targetTime);

--- a/src/flavors/standard/preview/usePreviewEngine.ts
+++ b/src/flavors/standard/preview/usePreviewEngine.ts
@@ -492,6 +492,12 @@ export function usePreviewEngine({
     targetStartSec: number;
     preseeked: boolean;
   }>>({});
+  const trimmedEntryLogStateRef = useRef<Record<string, {
+    preseekMissLogged: boolean;
+    holdSuppressedLogged: boolean;
+    startLatencyLogged: boolean;
+    boundaryEnterAtMs: number | null;
+  }>>({});
   const lastDrawableFrameRef = useRef<ImageBitmap | null>(null);
   const androidVisualBridgeStateRef = useRef<{ previousId: string | null; activeId: string | null; bridgeFrameCount: number; }>({
     previousId: null,
@@ -1054,7 +1060,12 @@ export function usePreviewEngine({
                 }
               } else if (isTrimmedEntry) {
                 entryState.holdFrameCount = 0;
-                logInfo('RENDER', 'preview.trimmedEntry.drift', {
+                const boundaryLogState = trimmedEntryLogStateRef.current[activeId] ?? { preseekMissLogged: false, holdSuppressedLogged: false, startLatencyLogged: false, boundaryEnterAtMs: null };
+                if (localTime <= 0.02 && boundaryLogState.boundaryEnterAtMs === null) {
+                  boundaryLogState.boundaryEnterAtMs = Date.now();
+                }
+                trimmedEntryLogStateRef.current[activeId] = boundaryLogState;
+                if (trimmedDrift >= 0.08) logInfo('RENDER', 'preview.trimmedEntry.drift', {
                   segmentIndex: activeIndex,
                   localTime,
                   trimStart,
@@ -1068,26 +1079,46 @@ export function usePreviewEngine({
                   holdFrame: false,
                   holdFrameCount: entryState.holdFrameCount,
                 });
-                if (trimmedDrift >= 0.08 && trimmedDrift < 0.2) {
+                if (trimmedDrift >= 0.08 && trimmedDrift < 0.15) {
                   logInfo('RENDER', 'preview.trimmedEntry.softDriftAllowed', {
                     segmentIndex: activeIndex,
                     drift: trimmedDrift,
                   });
                 }
-                if (!isPreseekReadyEntry && isPlayableTrimmedEntry) {
+                if (!isPreseekReadyEntry && isPlayableTrimmedEntry && !boundaryLogState.holdSuppressedLogged) {
+                  boundaryLogState.holdSuppressedLogged = true;
                   logInfo('RENDER', 'preview.trimmedEntry.holdSuppressed', {
                     segmentIndex: activeIndex,
                     drift: trimmedDrift,
                     preseekCompleted: !!preseekState?.completed,
                   });
                 }
-                if (!preseekState?.completed) {
+                if (!preseekState?.completed && !boundaryLogState.preseekMissLogged) {
+                  boundaryLogState.preseekMissLogged = true;
                   logWarn('RENDER', 'preview.trimmedEntry.preseekMiss', {
                     segmentIndex: activeIndex,
                     localTime,
                     trimStart,
                     drift: trimmedDrift,
                   });
+                }
+                if (!boundaryLogState.startLatencyLogged && boundaryLogState.boundaryEnterAtMs !== null) {
+                  const elapsed = Date.now() - boundaryLogState.boundaryEnterAtMs;
+                  const advancedMs = (activeEl.currentTime - trimStart) * 1000;
+                  if (elapsed >= 100 && advancedMs < 50) {
+                    boundaryLogState.startLatencyLogged = true;
+                    logWarn('RENDER', 'preview.nextVideo.startLatency', {
+                      segmentIndex: activeIndex,
+                      trimStart,
+                      boundaryGlobalTimeMs: Math.round((time - localTime) * 1000),
+                      videoCurrentTime: activeEl.currentTime,
+                      elapsedAfterBoundaryMs: elapsed,
+                      currentTimeAdvancedMs: advancedMs,
+                      readyState: activeEl.readyState,
+                      paused: activeEl.paused,
+                      seeking: activeEl.seeking,
+                    });
+                  }
                 }
               }
               let didApplyAndroidPreviewDriftFix = false;
@@ -1313,7 +1344,7 @@ export function usePreviewEngine({
               const shouldPreseekNextVideo =
                 isAndroidPreviewPlayback
                 && remainingTime >= 0
-                && remainingTime <= PREVIEW_ANDROID_NEXT_VIDEO_PREWARM_WINDOW_SEC
+                && remainingTime <= activeItem.duration
                 && nextVideoItem.type === 'video'
                 && (nextVideoItem.trimStart || 0) > 0;
               const nextStart = nextVideoItem.trimStart || 0;
@@ -1369,8 +1400,12 @@ export function usePreviewEngine({
                   preseeked: warmupState.preseeked,
                 });
               }
-              if (preseekState && (nextElement.readyState >= MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME || !nextElement.seeking)) {
-                preseekState.completed = true;
+              if (preseekState) {
+                const preseekDrift = Math.abs(nextElement.currentTime - preseekState.targetTime);
+                const hasFirstFrame = nextElement.videoWidth > 0 && nextElement.videoHeight > 0;
+                if (nextElement.readyState >= MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME && !nextElement.seeking && preseekDrift <= 0.05 && hasFirstFrame) {
+                  preseekState.completed = true;
+                }
               }
               if (!shouldPreseekNextVideo && (nextElement.paused || nextElement.readyState < 2)) {
                 if (Math.abs(nextElement.currentTime - nextStart) > 0.1) {
@@ -3099,11 +3134,33 @@ export function usePreviewEngine({
             return;
           }
         }
+        const nextVideoElForPreflight = nextVideoItem?.type === 'video'
+          ? mediaElementsRef.current[nextVideoItem.id] as HTMLVideoElement | undefined
+          : undefined;
+        const nextTrimStart = nextVideoItem?.trimStart || 0;
+        const nextPreseekState = nextVideoItem ? androidTrimPreseekRef.current[nextVideoItem.id] : undefined;
+        const nextPreseekDrift = nextVideoElForPreflight
+          ? Math.abs(nextVideoElForPreflight.currentTime - nextTrimStart)
+          : Infinity;
+        const isNextVideoReady = !nextVideoItem || (
+          !!nextVideoElForPreflight
+          && !!nextVideoElForPreflight.currentSrc
+          && nextVideoElForPreflight.readyState >= MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME
+          && nextVideoElForPreflight.videoWidth > 0
+          && nextVideoElForPreflight.videoHeight > 0
+          && !!nextPreseekState?.completed
+          && nextPreseekDrift <= 0.05
+        );
+
         logInfo('RENDER', 'preview.preflight.ready', {
           globalTimeMs: Math.round(fromTime * 1000),
           totalDurationMs: Math.round(totalDurationRef.current * 1000),
           hasActiveVideo: !!activeVideoElForBundledStart,
+          activeVideoReadyState: activeVideoElForBundledStart?.readyState ?? null,
           hasNextVideo: !!nextVideoItem,
+          nextVideoReady: isNextVideoReady,
+          preseekCompleted: !!nextPreseekState?.completed,
+          preseekDrift: Number.isFinite(nextPreseekDrift) ? nextPreseekDrift : null,
         });
 
         if (preparedPreviewAudio.requiresWebAudio) {

--- a/src/flavors/standard/preview/usePreviewEngine.ts
+++ b/src/flavors/standard/preview/usePreviewEngine.ts
@@ -1063,6 +1063,10 @@ export function usePreviewEngine({
                 const boundaryLogState = trimmedEntryLogStateRef.current[activeId] ?? { preseekMissLogged: false, holdSuppressedLogged: false, startLatencyLogged: false, boundaryEnterAtMs: null };
                 if (localTime <= 0.02 && boundaryLogState.boundaryEnterAtMs === null) {
                   boundaryLogState.boundaryEnterAtMs = Date.now();
+                } else if (localTime > PREVIEW_ANDROID_TRIMMED_VIDEO_HEAD_HOLD_WINDOW_SEC && boundaryLogState.boundaryEnterAtMs !== null) {
+                  // 同じ境界への再突入時に start latency の経過時間を初期化する。
+                  boundaryLogState.boundaryEnterAtMs = null;
+                  boundaryLogState.startLatencyLogged = false;
                 }
                 trimmedEntryLogStateRef.current[activeId] = boundaryLogState;
                 if (trimmedDrift >= 0.08) logInfo('RENDER', 'preview.trimmedEntry.drift', {
@@ -1120,6 +1124,14 @@ export function usePreviewEngine({
                     });
                   }
                 }
+              } else if (trimmedEntryLogStateRef.current[activeId]?.boundaryEnterAtMs !== null) {
+                // 境界ヘッド区間を離脱したら次回の再突入検知に備えて reset する。
+                trimmedEntryLogStateRef.current[activeId] = {
+                  preseekMissLogged: false,
+                  holdSuppressedLogged: false,
+                  startLatencyLogged: false,
+                  boundaryEnterAtMs: null,
+                };
               }
               let didApplyAndroidPreviewDriftFix = false;
               if (

--- a/src/test/standardPreviewEngine.test.tsx
+++ b/src/test/standardPreviewEngine.test.tsx
@@ -1000,7 +1000,7 @@ describe('standard preview engine', () => {
     expect(farVideoElement.currentTime).toBeCloseTo(0.2);
   });
 
-  it('Android preview の next trimmed video preseek は clip 終端 0.8 秒の外では発火しない', () => {
+  it('Android preview の next trimmed video preseek は clip 開始直後から発火する', () => {
     const imageItem = createImageItem({ id: 'image-gap', duration: 1 });
     const videoItem = createVideoItem({
       id: 'video-2',
@@ -1023,7 +1023,7 @@ describe('standard preview engine', () => {
 
     hook.result.current.renderFrame(0.19, true, false);
 
-    expect(videoElement.currentTime).toBeCloseTo(0.2);
+    expect(videoElement.currentTime).toBeCloseTo(videoItem.trimStart);
   });
 
   it('Android preview の next trimmed video preseek は同じ trimStart へ連続発火しない', () => {


### PR DESCRIPTION
### Motivation
- preview.preflight.ready が `hasNextVideo=true` だけで ready 扱いになり、次動画の trimStart への事前 seek/warmup 未完了で境界直後に `preview.trimmedEntry.preseekMiss` が発生していたため、動画間で引っかかり（drift）や再生遅延が発生していた。 
- 次動画が存在するだけで ready とする判定を止め、active と next の両方の再生準備（preseekCompleted / first frame / readyState 等）を確認する必要があった。 
- 境界周りのログが毎フレーム大量に出てノイズになっていたため、重要な状態変化のみを記録する方針にする必要があった。 

### Description
- 境界単位のログ抑制用に `trimmedEntryLogStateRef` を追加し、`preseekMiss` を boundary ごと1回、`holdSuppressed` を状態変化時のみ、`preview.trimmedEntry.drift` はしきい値以上（>= 80ms/150ms 相当）でのみ出力するように変更した。 
- 次動画の preseek 開始判定を従来の「終端近傍のみ」から active clip 再生中に早期開始できるようにし（`remainingTime <= activeItem.duration` に拡張）、preseek の完了条件を `readyState >= MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME`・`!seeking`・`drift <= 0.05`・最初のフレームが得られていることに厳格化した。 
- `preview.preflight.ready` ログ出力を強化して、単に `hasNextVideo` を出すだけでなく `activeVideoReadyState`、`nextVideoReady`、`preseekCompleted`、`preseekDrift` を含めて出力するようにした。 
- 境界後 100ms 以内に次動画の `currentTime` が進まない場合に `preview.nextVideo.startLatency` 警告を1回だけ出すロジックを追加した。 
- テスト側の期待値を新仕様に合わせて更新し（該当ケースで preseek が clip 開始直後から発火するように修正）、関連の unit test を修正した。 

### Testing
- `pnpm -s test src/test/standardPreviewEngine.test.tsx` を実行し、対象ファイル内の全テスト（21件）がパスしたことを確認した。 
- 変更はユニットテスト対象のシナリオに合わせて期待値を更新しており、該当テストファイルはすべて成功した。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f52beb263c8325b4ba5e19c2b44204)