### PR TITLE
Android プレビュー境界の preseek/warmup 判定を厳格化し drawable 時の hold を抑止

### DIFF
--- a/.agents/skills/turtle-video-overview/references/implementation-patterns.md
+++ b/.agents/skills/turtle-video-overview/references/implementation-patterns.md
@@ -1789,3 +1789,18 @@
 - **注意点**:
   - 境界 300ms 以内は clock rebase を抑制し、`drift>400ms` かつ drawable でない破綻時に限定する。
   - drawable かつ再生中 (`readyState>=3 && !paused && !seeking`) の場合は holdFrame を優先しない。
+
+### 13-93. Android trimmed boundary では active/next の warmup 完了を厳格化し、drawable 時の hold を禁止する
+
+- **ファイル**: `src/flavors/standard/preview/usePreviewEngine.ts`
+- **問題**:
+  - 境界直前まで preseek/warmup を実施していても、active 側で `preseeked=false` 相当の状態が残ると `preseekMiss` と `startLatency` が再発しやすい。
+  - drawable (`readyState>=3 && !paused && !seeking && videoWidth/Height>0`) なフレームでも hold を発動すると、境界で瞬停として知覚される。
+- **対策**:
+  - trimmed entry の `isPreseekReadyEntry` 判定に `activeWarmupState.preseeked` と `decoderWarmupCompleted` を追加し、active 昇格時に warmup 未完了を明確に弾く。
+  - `preview.trimmedEntry.preseekMiss` に warmup 実行/完了、active ready/paused/seeking を添えて「未実行か状態喪失か」を切り分け可能にする。
+  - 境界前 warmup は `trimStart-0.3s` 起点で hidden muted play を行い、`currentTime` が 80ms 以上前進した実績が確認できた場合のみ `decoderWarmupCompleted=true` にする。
+  - drawable 時は `holdFrame=false` を維持し、diagnostic の hold 表示も実際の挙動に一致させる。
+- **注意点**:
+  - この対策は Android preview 専用で、iOS/PC の共有経路や完了後 freeze の見た目ロジックは変更しない。
+  - warmup 状態を trimStart 変更時に reset する際は `warmupStartAtSec` も同時に初期化し、古い進行量を再利用しない。

--- a/src/flavors/standard/preview/usePreviewEngine.ts
+++ b/src/flavors/standard/preview/usePreviewEngine.ts
@@ -1452,14 +1452,18 @@ export function usePreviewEngine({
                   nextElement.muted = true;
                   nextElement.defaultMuted = true;
                   nextElement.playsInline = true;
-                  if (Math.abs(nextElement.currentTime - warmupTarget) > 0.03) {
-                    nextElement.currentTime = warmupTarget;
-                  }
+                  const currentTimeBeforeWarmupSeek = nextElement.currentTime;
                   if (warmupState.warmupStartAtSec === null) {
+                    if (Math.abs(nextElement.currentTime - warmupTarget) > 0.03) {
+                      nextElement.currentTime = warmupTarget;
+                    }
                     warmupState.warmupStartAtSec = nextElement.currentTime;
                   }
                   void nextElement.play().catch(() => undefined);
-                  const warmupAdvancedMs = Math.max(0, (nextElement.currentTime - warmupState.warmupStartAtSec) * 1000);
+                  const warmupAdvancedMs = Math.max(
+                    0,
+                    (currentTimeBeforeWarmupSeek - warmupState.warmupStartAtSec) * 1000,
+                  );
                   if (
                     warmupAdvancedMs >= 80
                     && !nextElement.paused

--- a/src/flavors/standard/preview/usePreviewEngine.ts
+++ b/src/flavors/standard/preview/usePreviewEngine.ts
@@ -492,6 +492,7 @@ export function usePreviewEngine({
     targetStartSec: number;
     preseeked: boolean;
     decoderWarmupCompleted: boolean;
+    warmupStartAtSec: number | null;
   }>>({});
   const trimmedEntryLogStateRef = useRef<Record<string, {
     preseekMissLogged: boolean;
@@ -992,8 +993,11 @@ export function usePreviewEngine({
               const preseekState = androidTrimPreseekRef.current[activeId];
               const preseekDrift = Math.abs(activeEl.currentTime - targetTime);
               const trimmedDrift = Math.abs(activeEl.currentTime - targetTime);
+              const activeWarmupState = androidBoundaryWarmupRef.current[activeId];
               const isPreseekReadyEntry =
                 !!preseekState?.completed
+                && !!activeWarmupState?.preseeked
+                && !!activeWarmupState?.decoderWarmupCompleted
                 && activeEl.readyState >= MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME
                 && !activeEl.seeking
                 && preseekDrift <= 0.12;
@@ -1071,7 +1075,7 @@ export function usePreviewEngine({
                   seeking: activeEl.seeking,
                   didHardSeek: entryState.didHardSeek,
                   didRebaseClock: entryState.didRebaseClock,
-                  holdFrame: true,
+                  holdFrame: !isDrawablePlaying,
                   holdFrameCount: entryState.holdFrameCount,
                   preseekCompleted: !!preseekState?.completed,
                   preseekDrift,
@@ -1115,6 +1119,12 @@ export function usePreviewEngine({
                     localTime,
                     trimStart,
                     drift: trimmedDrift,
+                    warmupExecuted: !!activeWarmupState?.preseeked,
+                    warmupCompleted: !!activeWarmupState?.decoderWarmupCompleted,
+                    preseekCompleted: !!preseekState?.completed,
+                    activeReadyState: activeEl.readyState,
+                    activePaused: activeEl.paused,
+                    activeSeeking: activeEl.seeking,
                   });
                 }
                 if (!boundaryLogState.startLatencyLogged && boundaryLogState.boundaryEnterAtMs !== null) {
@@ -1376,11 +1386,13 @@ export function usePreviewEngine({
                   targetStartSec: nextStart,
                   preseeked: false,
                   decoderWarmupCompleted: false,
+                  warmupStartAtSec: null,
                 };
               if (Math.abs(warmupState.targetStartSec - nextStart) > 0.001) {
                 warmupState.targetStartSec = nextStart;
                 warmupState.preseeked = false;
                 warmupState.decoderWarmupCompleted = false;
+                warmupState.warmupStartAtSec = null;
               }
               androidBoundaryWarmupRef.current[nextVideoItem.id] = warmupState;
               const preseekState = androidTrimPreseekRef.current[nextVideoItem.id];
@@ -1428,14 +1440,14 @@ export function usePreviewEngine({
               }
               if (
                 isAndroidPreviewPlayback
-                && remainingTime <= 0.25
+                && remainingTime <= 0.30
                 && remainingTime >= 0
                 && !warmupState.decoderWarmupCompleted
                 && !!preseekState?.completed
                 && nextElement.readyState >= MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME
                 && !nextElement.seeking
               ) {
-                const warmupTarget = Math.max(0, nextStart - 0.25);
+                const warmupTarget = Math.max(0, nextStart - 0.3);
                 try {
                   nextElement.muted = true;
                   nextElement.defaultMuted = true;
@@ -1443,11 +1455,19 @@ export function usePreviewEngine({
                   if (Math.abs(nextElement.currentTime - warmupTarget) > 0.03) {
                     nextElement.currentTime = warmupTarget;
                   }
-                  void nextElement.play()
-                    .catch(() => undefined)
-                    .finally(() => {
-                      warmupState.decoderWarmupCompleted = true;
-                    });
+                  if (warmupState.warmupStartAtSec === null) {
+                    warmupState.warmupStartAtSec = nextElement.currentTime;
+                  }
+                  void nextElement.play().catch(() => undefined);
+                  const warmupAdvancedMs = Math.max(0, (nextElement.currentTime - warmupState.warmupStartAtSec) * 1000);
+                  if (
+                    warmupAdvancedMs >= 80
+                    && !nextElement.paused
+                    && !nextElement.seeking
+                    && nextElement.readyState >= MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME
+                  ) {
+                    warmupState.decoderWarmupCompleted = true;
+                  }
                 } catch {
                   // ignore
                 }


### PR DESCRIPTION
### Motivation
- Android プレビューの境界で `preseekMiss` / `startLatency` / 瞬停が再発しているため、影響範囲を限定して境界準備判定と hold 挙動を修正する必要があった。 
- 変更は広範囲に及ばせず、主に trimmed-entry 境界周りの warmup/preseek ロジックだけを強化する方針とした。 
- 目的は境界で `preseeked=false` のまま入らないようにし、drawable な video に対して不必要な `holdFrame` を発動させないことです。 

### Description
- `isPreseekReadyEntry` の判定を強化して、active 側の warmup フラグ `preseeked` と `decoderWarmupCompleted` が揃っていない場合は境界準備完了とみなさないようにした（`src/flavors/standard/preview/usePreviewEngine.ts`）。
- 境界前の warmup を `trimStart - 0.3s` 起点に変更し、hidden/muted で短時間再生して `currentTime` が実際に進んだこと（>= 80ms）を確認してから `decoderWarmupCompleted=true` にするために `warmupStartAtSec` を導入して進行を計測するロジックを追加した。 
- drawable（`readyState>=3 && !paused && !seeking && videoWidth/Height>0`）なフレームでは hold を抑止し、診断ログの `holdFrame` 表示も実挙動 (`!isDrawablePlaying`) に合わせて修正した。 
- `preview.trimmedEntry.preseekMiss` のログ出力に warmup 実行/完了や active の ready/paused/seeking 情報を追加して、未実行か状態喪失かを切り分けられるようにした。 
- 作業にあたり `bugfix-guard` と `turtle-video-overview` スキルを参照し、修正方針の遵守とドキュメント追記を行い、対応パターンを `.agents/skills/turtle-video-overview/references/implementation-patterns.md` に追加した。 
- 変更対象ファイル: `src/flavors/standard/preview/usePreviewEngine.ts` とオーバービュー参照の追記 ` .agents/skills/turtle-video-overview/references/implementation-patterns.md`。 

### Testing
- 単体テストを `npm run test:run -- src/test/standardPreviewEngine.test.tsx` で実行し、`21` テストがすべて合格しました。 
- ビルドを `npm run build` で実行し、TypeScript コンパイルと Vite ビルドが成功しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f58ab98f7483258923b77bb3a96d53)