### PR TITLE
Fix Android preview warmup gating regression

### DIFF
--- a/.agents/skills/turtle-video-overview/references/implementation-patterns.md
+++ b/.agents/skills/turtle-video-overview/references/implementation-patterns.md
@@ -131,6 +131,20 @@
   - `alignedDurationSec` / `alignedDurationUs` は frame count 診断やデバッグ用途として残っていても、Teams 対策の実処理基準に混ぜない
   - raw duration へ戻す修正は export 専用で、preview の再生・シーク・停止や iOS Safari workaround へ波及させない
 
+### 0-10. Android preview 境界の next video warmup は「実行済み状態」を必須にする
+
+- **ファイル**: `src/flavors/standard/preview/usePreviewEngine.ts`
+- **背景**:
+  - `readyState=4` かつ次動画が存在していても、境界前 warmup が未実行だと `preview.trimmedEntry.preseekMiss` / `preview.nextVideo.startLatency` が再発し、境界直後の進みが鈍って `drift` が増える
+  - 特に Android は decoder warmup が未完了のまま active 昇格すると、最初の 100ms 前後で停止体感が残りやすい
+- **実装指針**:
+  - 境界 500ms 前から next video warmup を開始し、`warmupExecuted` / `warmupCompleted` / `preseekCompleted` / `decoderWarmupCompleted` を state で保持する
+  - `preview.preflight.ready` は上記 4 フラグが true になるまで成功扱いにしない（Android + 次動画ありの場合）
+  - 境界ログで warmup state を必ず出し、active 昇格時の state 持ち越し成否（`stateCarriedToActive` / `stateLost`）を診断可能にする
+- **注意点**:
+  - holdFrame 条件や drift 閾値の緩和だけで品質問題を覆い隠さない
+  - warmup 失敗時は warning を残し、次動画デコード未準備のまま smooth 扱いにしない
+
 ## 1. スクロール/スワイプ誤操作防止
 
 ### 1-1. モーダル表示時のボディスクロールロック

--- a/src/flavors/standard/preview/usePreviewEngine.ts
+++ b/src/flavors/standard/preview/usePreviewEngine.ts
@@ -1496,7 +1496,8 @@ export function usePreviewEngine({
                 && nextElement.readyState >= MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME
                 && !nextElement.seeking
               ) {
-                const warmupTarget = Math.max(0, nextStart - 0.3);
+                const warmupLeadTimeSec = Math.min(0.50, Math.max(0, remainingTime));
+                const warmupTarget = Math.max(0, nextStart - warmupLeadTimeSec);
                 try {
                   if (!warmupState.warmupExecuted) {
                     logInfo('RENDER', 'preview.warmup.start', {
@@ -1504,6 +1505,7 @@ export function usePreviewEngine({
                       nextId: nextVideoItem.id,
                       remainingSec: remainingTime,
                       warmupTargetSec: warmupTarget,
+                      warmupLeadTimeSec,
                     });
                   }
                   warmupState.warmupExecuted = true;

--- a/src/flavors/standard/preview/usePreviewEngine.ts
+++ b/src/flavors/standard/preview/usePreviewEngine.ts
@@ -236,7 +236,7 @@ const PREVIEW_ANDROID_BGM_SOFT_SYNC_TOLERANCE_SEC = 0.3;
 const PREVIEW_END_THRESHOLD_SEC = 0.03;
 // 再生開始直後は seeked / canplay の到着を数フレームだけ待ち、遅ければ loop を止めない。
 const PREVIEW_START_READY_POLL_INTERVAL_MS = 40;
-const PREVIEW_START_READY_TIMEOUT_MS = 900;
+const PREVIEW_START_READY_TIMEOUT_MS = 800;
 const DISPLAY_TIME_CLAMP_EPSILON_SEC = 0.001;
 const PREVIEW_DETAILED_TICK_LOG_INTERVAL_MS = 500;
 
@@ -491,8 +491,12 @@ export function usePreviewEngine({
   const androidBoundaryWarmupRef = useRef<Record<string, {
     targetStartSec: number;
     preseeked: boolean;
+    warmupExecuted: boolean;
+    warmupCompleted: boolean;
+    preseekCompleted: boolean;
     decoderWarmupCompleted: boolean;
     warmupStartAtSec: number | null;
+    warmupAdvancedMs: number;
   }>>({});
   const trimmedEntryLogStateRef = useRef<Record<string, {
     preseekMissLogged: boolean;
@@ -828,6 +832,27 @@ export function usePreviewEngine({
               const targetTime = (activeItem.trimStart || 0) + localTime;
               const trimStart = activeItem.trimStart || 0;
               const warmupState = androidBoundaryWarmupRef.current[activeId];
+              if (isAndroidPreviewPlayback && localTime >= 0 && localTime <= 0.12) {
+                if (warmupState?.warmupExecuted && warmupState?.warmupCompleted && warmupState?.preseekCompleted) {
+                  logInfo('RENDER', 'preview.warmup.stateCarriedToActive', {
+                    activeId,
+                    preseeked: !!warmupState.preseeked,
+                    warmupExecuted: !!warmupState.warmupExecuted,
+                    warmupCompleted: !!warmupState.warmupCompleted,
+                    preseekCompleted: !!warmupState.preseekCompleted,
+                    decoderWarmupCompleted: !!warmupState.decoderWarmupCompleted,
+                  });
+                } else {
+                  logWarn('RENDER', 'preview.warmup.stateLost', {
+                    activeId,
+                    preseeked: !!warmupState?.preseeked,
+                    warmupExecuted: !!warmupState?.warmupExecuted,
+                    warmupCompleted: !!warmupState?.warmupCompleted,
+                    preseekCompleted: !!warmupState?.preseekCompleted,
+                    decoderWarmupCompleted: !!warmupState?.decoderWarmupCompleted,
+                  });
+                }
+              }
               const entryState = androidTrimEntryStateRef.current[activeId]
                 ?? { didHardSeek: false, didRebaseClock: false, holdFrameCount: 0 };
               androidTrimEntryStateRef.current[activeId] = entryState;
@@ -1119,12 +1144,16 @@ export function usePreviewEngine({
                     localTime,
                     trimStart,
                     drift: trimmedDrift,
-                    warmupExecuted: !!activeWarmupState?.preseeked,
-                    warmupCompleted: !!activeWarmupState?.decoderWarmupCompleted,
+                    warmupExecuted: !!activeWarmupState?.warmupExecuted,
+                    warmupCompleted: !!activeWarmupState?.warmupCompleted,
                     preseekCompleted: !!preseekState?.completed,
+                    decoderWarmupCompleted: !!activeWarmupState?.decoderWarmupCompleted,
+                    preseeked: !!activeWarmupState?.preseeked,
                     activeReadyState: activeEl.readyState,
                     activePaused: activeEl.paused,
                     activeSeeking: activeEl.seeking,
+                    videoCurrentTime: activeEl.currentTime,
+                    targetTime,
                   });
                 }
                 if (!boundaryLogState.startLatencyLogged && boundaryLogState.boundaryEnterAtMs !== null) {
@@ -1385,14 +1414,27 @@ export function usePreviewEngine({
                 ?? {
                   targetStartSec: nextStart,
                   preseeked: false,
+                  warmupExecuted: false,
+                  warmupCompleted: false,
+                  preseekCompleted: false,
                   decoderWarmupCompleted: false,
                   warmupStartAtSec: null,
+                  warmupAdvancedMs: 0,
                 };
               if (Math.abs(warmupState.targetStartSec - nextStart) > 0.001) {
                 warmupState.targetStartSec = nextStart;
                 warmupState.preseeked = false;
+                warmupState.warmupExecuted = false;
+                warmupState.warmupCompleted = false;
+                warmupState.preseekCompleted = false;
                 warmupState.decoderWarmupCompleted = false;
                 warmupState.warmupStartAtSec = null;
+                warmupState.warmupAdvancedMs = 0;
+                logInfo('RENDER', 'preview.warmup.cancelled', {
+                  nextId: nextVideoItem.id,
+                  reason: 'target_changed',
+                  targetStartSec: nextStart,
+                });
               }
               androidBoundaryWarmupRef.current[nextVideoItem.id] = warmupState;
               const preseekState = androidTrimPreseekRef.current[nextVideoItem.id];
@@ -1427,6 +1469,7 @@ export function usePreviewEngine({
                   currentTime: nextElement.currentTime,
                 });
                 warmupState.preseeked = true;
+                warmupState.preseekCompleted = false;
                 logInfo('RENDER', '[DIAG-BOUNDARY-WARMUP] next video preseek requested', {
                   activeId,
                   nextId: nextVideoItem.id,
@@ -1437,40 +1480,72 @@ export function usePreviewEngine({
                   seeking: nextElement.seeking,
                   preseeked: warmupState.preseeked,
                 });
+                logInfo('RENDER', 'preview.warmup.schedule', {
+                  activeId,
+                  nextId: nextVideoItem.id,
+                  remainingSec: remainingTime,
+                  targetStartSec: nextStart,
+                });
               }
               if (
                 isAndroidPreviewPlayback
-                && remainingTime <= 0.30
+                && remainingTime <= 0.50
                 && remainingTime >= 0
-                && !warmupState.decoderWarmupCompleted
+                && !warmupState.warmupCompleted
                 && !!preseekState?.completed
                 && nextElement.readyState >= MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME
                 && !nextElement.seeking
               ) {
                 const warmupTarget = Math.max(0, nextStart - 0.3);
                 try {
+                  if (!warmupState.warmupExecuted) {
+                    logInfo('RENDER', 'preview.warmup.start', {
+                      activeId,
+                      nextId: nextVideoItem.id,
+                      remainingSec: remainingTime,
+                      warmupTargetSec: warmupTarget,
+                    });
+                  }
+                  warmupState.warmupExecuted = true;
                   nextElement.muted = true;
                   nextElement.defaultMuted = true;
                   nextElement.playsInline = true;
-                  const currentTimeBeforeWarmupSeek = nextElement.currentTime;
                   if (warmupState.warmupStartAtSec === null) {
                     if (Math.abs(nextElement.currentTime - warmupTarget) > 0.03) {
                       nextElement.currentTime = warmupTarget;
                     }
                     warmupState.warmupStartAtSec = nextElement.currentTime;
                   }
-                  void nextElement.play().catch(() => undefined);
-                  const warmupAdvancedMs = Math.max(
-                    0,
-                    (currentTimeBeforeWarmupSeek - warmupState.warmupStartAtSec) * 1000,
-                  );
+                  void nextElement.play().then(() => {
+                    logInfo('RENDER', 'preview.warmup.playResolved', {
+                      nextId: nextVideoItem.id,
+                      paused: nextElement.paused,
+                      readyState: nextElement.readyState,
+                    });
+                  }).catch(() => undefined);
+                  const warmupAdvancedMs = warmupState.warmupStartAtSec === null
+                    ? 0
+                    : Math.max(0, (nextElement.currentTime - warmupState.warmupStartAtSec) * 1000);
+                  warmupState.warmupAdvancedMs = warmupAdvancedMs;
+                  logInfo('RENDER', 'preview.warmup.currentTimeAdvanced', {
+                    nextId: nextVideoItem.id,
+                    warmupAdvancedMs,
+                    currentTime: nextElement.currentTime,
+                    warmupStartAtSec: warmupState.warmupStartAtSec,
+                  });
                   if (
                     warmupAdvancedMs >= 80
                     && !nextElement.paused
                     && !nextElement.seeking
                     && nextElement.readyState >= MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME
                   ) {
+                    warmupState.warmupCompleted = true;
+                    warmupState.preseekCompleted = true;
                     warmupState.decoderWarmupCompleted = true;
+                    logInfo('RENDER', 'preview.warmup.completed', {
+                      nextId: nextVideoItem.id,
+                      warmupAdvancedMs,
+                    });
                   }
                 } catch {
                   // ignore
@@ -1496,6 +1571,7 @@ export function usePreviewEngine({
                   && currentTimeAdvancedMs >= 80;
                 if (basePreseekReady && (nextElement.paused || progressedWhilePlaying)) {
                   preseekState.completed = true;
+                  warmupState.preseekCompleted = true;
                 }
               }
               if (!shouldPreseekNextVideo && (nextElement.paused || nextElement.readyState < 2)) {
@@ -3250,12 +3326,17 @@ export function usePreviewEngine({
           ? Math.abs(activeVideoElForBundledStart.currentTime - activeVideoTargetTime)
           : Infinity;
         const nextWarmupState = nextVideoItem ? androidBoundaryWarmupRef.current[nextVideoItem.id] : undefined;
-        const isDecoderWarmed = !platformCapabilities.isAndroid || !nextVideoItem || !!nextWarmupState?.decoderWarmupCompleted;
+        const isAndroidWarmupReady = !platformCapabilities.isAndroid || !nextVideoItem || (
+          !!nextWarmupState?.warmupExecuted
+          && !!nextWarmupState?.warmupCompleted
+          && !!nextWarmupState?.preseekCompleted
+          && !!nextWarmupState?.decoderWarmupCompleted
+        );
         const isPreflightReady = !!activeVideoElForBundledStart
           && activeVideoElForBundledStart.readyState >= 3
           && activeTrimDrift <= 0.05
           && isNextVideoReady
-          && isDecoderWarmed;
+          && isAndroidWarmupReady;
         if (isPreflightReady) logInfo('RENDER', 'preview.preflight.ready', {
           globalTimeMs: Math.round(fromTime * 1000),
           totalDurationMs: Math.round(totalDurationRef.current * 1000),
@@ -3265,6 +3346,9 @@ export function usePreviewEngine({
           nextVideoReady: isNextVideoReady,
           preseekCompleted: !!nextPreseekState?.completed,
           preseekDrift: Number.isFinite(nextPreseekDrift) ? nextPreseekDrift : null,
+          warmupExecuted: !!nextWarmupState?.warmupExecuted,
+          warmupCompleted: !!nextWarmupState?.warmupCompleted,
+          warmupPreseekCompleted: !!nextWarmupState?.preseekCompleted,
           decoderWarmupCompleted: !!nextWarmupState?.decoderWarmupCompleted,
           activeTrimDrift,
         });


### PR DESCRIPTION
### Motivation
- Android プレビューで境界前の next video warmup が実行されていない／active 昇格時に状態が引き継がれていないため、`preview.trimmedEntry.preseekMiss` や `preview.nextVideo.startLatency` が発生して境界直後に再生進行が鈍り drift が増加していた。
- holdFrame や drift 閾値の緩和で誤魔化すのではなく、境界前に確実に warmup を実行・完了させることで根本原因を除去する必要があった。

### Description
- `androidBoundaryWarmupRef` に `warmupExecuted`, `warmupCompleted`, `preseekCompleted`, `warmupAdvancedMs` を追加して warmup ライフサイクルを明示的に管理するようにした。 (変更: `src/flavors/standard/preview/usePreviewEngine.ts`)
- 境界前 warmup の起動タイミングを従来の ~300ms から少なくとも `500ms` 前に拡張し、warmup 実行時に `preview.warmup.schedule` / `preview.warmup.start` / `preview.warmup.playResolved` / `preview.warmup.currentTimeAdvanced` / `preview.warmup.completed` / `preview.warmup.cancelled` ログを追加した。 (変更: `usePreviewEngine.ts`)
- `preview.preflight.ready` の判定を強化し、Android かつ次動画が存在する場合は `warmupExecuted && warmupCompleted && preseekCompleted && decoderWarmupCompleted` が揃っていない限り ready 扱いにしないようにした（タイムアウトは短縮して 800ms に調整）。 (変更: `usePreviewEngine.ts`)
- 境界診断ログを拡張し `preview.trimmedEntry.preseekMiss` に warmup / preseek の詳細フィールドと `videoCurrentTime`/`targetTime` を出力するようにし、active 昇格時に状態が継承されたかを示す `preview.warmup.stateCarriedToActive` / `preview.warmup.stateLost` ログを追加した。 (変更: `usePreviewEngine.ts`)
- 実装パターン資料に Android 境界 warmup の方針を追記して、今後の修正で同様の regression を回避するための指針を追加した。 (変更: `.agents/skills/turtle-video-overview/references/implementation-patterns.md`)

### Testing
- `npm run test:run -- src/test/previewPlatform.test.ts` を実行し、該当テストファイルの 53 テストがすべて成功しました。 (結果: 53 passed)
- `npm run build` を実行して TypeScript コンパイルと Vite ビルドを行い、ビルドは成功しました。 (結果: 成功)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5913115b8832590536c0cd2aeb315)