### PR TITLE
Follow-up: bound Android warmup lead time by trimStart in preview engine

### DIFF
--- a/src/flavors/standard/preview/usePreviewEngine.ts
+++ b/src/flavors/standard/preview/usePreviewEngine.ts
@@ -1496,8 +1496,11 @@ export function usePreviewEngine({
                 && nextElement.readyState >= MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME
                 && !nextElement.seeking
               ) {
-                const warmupLeadTimeSec = Math.min(0.50, Math.max(0, remainingTime));
-                const warmupTarget = Math.max(0, nextStart - warmupLeadTimeSec);
+                const boundedWarmupLeadTimeSec = Math.max(
+                  0,
+                  Math.min(0.50, remainingTime, nextStart),
+                );
+                const warmupTarget = Math.max(0, nextStart - boundedWarmupLeadTimeSec);
                 try {
                   if (!warmupState.warmupExecuted) {
                     logInfo('RENDER', 'preview.warmup.start', {
@@ -1505,7 +1508,7 @@ export function usePreviewEngine({
                       nextId: nextVideoItem.id,
                       remainingSec: remainingTime,
                       warmupTargetSec: warmupTarget,
-                      warmupLeadTimeSec,
+                      warmupLeadTimeSec: boundedWarmupLeadTimeSec,
                     });
                   }
                   warmupState.warmupExecuted = true;


### PR DESCRIPTION
### Motivation
- Fix a P1 regression where Android preview warmup could advance the next video past a short `trimStart` (e.g. `trimStart < 0.5s`) because `warmupTarget` was clamped to `0`, causing pre-boundary drift.

### Description
- Change in `src/flavors/standard/preview/usePreviewEngine.ts`: replace `warmupLeadTimeSec = min(0.50, max(0, remainingTime))` with `boundedWarmupLeadTimeSec = max(0, min(0.50, remainingTime, nextStart))` and use it to compute `warmupTarget` and diagnostic logs so warmup never leads beyond `trimStart` for very short trims.

### Testing
- Ran `npm run test:run -- src/test/previewPlatform.test.ts` and all tests passed (`53 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5a8d9a9ac8325b3a5290f48f33591)