### PR TITLE
fix(android-preview): Android プレビュー境界の preroll/warmup/hard-seek 経路を無効化して再生不正を止血

### DIFF
--- a/src/flavors/standard/preview/usePreviewEngine.ts
+++ b/src/flavors/standard/preview/usePreviewEngine.ts
@@ -1341,7 +1341,8 @@ export function usePreviewEngine({
             && !endFinalizedRef.current
             && totalDurationRef.current > 0
             && time < totalDurationRef.current
-            && hasDrawableActiveVideo;
+            && hasDrawableActiveVideo
+            && !hasExplicitFadeToBlack;
           if (shouldSuppressEndClear) {
             if (previewTimelineDiagnosticsRef.current.lastShouldSuppressEndClear !== true) {
               logInfo('RENDER', 'preview.endClear.suppressed', {

--- a/src/flavors/standard/preview/usePreviewEngine.ts
+++ b/src/flavors/standard/preview/usePreviewEngine.ts
@@ -230,7 +230,6 @@ const PREVIEW_ANDROID_TRIMMED_VIDEO_SYNC_TOLERANCE_SEC = 0.05;
 const PREVIEW_ANDROID_TRIMMED_VIDEO_HEAD_HOLD_WINDOW_SEC = 0.25;
 const PREVIEW_ANDROID_BOUNDARY_DRAW_DRIFT_ALLOWANCE_SEC = 0.25;
 const PREVIEW_ANDROID_MAX_VISUAL_BRIDGE_FRAMES = 2;
-const TRIMMED_ENTRY_HARD_SEEK_THRESHOLD_SEC = 0.25;
 const TRIMMED_ENTRY_SOFT_DRIFT_ALLOWANCE_SEC = 0.35;
 const PREVIEW_ANDROID_BGM_SOFT_SYNC_TOLERANCE_SEC = 0.3;
 const PREVIEW_END_THRESHOLD_SEC = 0.03;
@@ -1018,11 +1017,8 @@ export function usePreviewEngine({
               const preseekState = androidTrimPreseekRef.current[activeId];
               const preseekDrift = Math.abs(activeEl.currentTime - targetTime);
               const trimmedDrift = Math.abs(activeEl.currentTime - targetTime);
-              const activeWarmupState = androidBoundaryWarmupRef.current[activeId];
               const isPreseekReadyEntry =
                 !!preseekState?.completed
-                && !!activeWarmupState?.preseeked
-                && !!activeWarmupState?.decoderWarmupCompleted
                 && activeEl.readyState >= MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME
                 && !activeEl.seeking
                 && preseekDrift <= 0.12;
@@ -1046,23 +1042,7 @@ export function usePreviewEngine({
                   || trimmedDrift > PREVIEW_ANDROID_TRIMMED_VIDEO_SYNC_TOLERANCE_SEC
                 )
               ) {
-                if (
-                  activeEl.readyState >= MIN_VIDEO_READY_STATE_FOR_SEEK
-                  && !activeEl.seeking
-                  && !entryState.didHardSeek
-                  && trimmedDrift > TRIMMED_ENTRY_HARD_SEEK_THRESHOLD_SEC
-                ) {
-                  activeEl.currentTime = targetTime;
-                  entryState.didHardSeek = true;
-                  logInfo('RENDER', '[DIAG-TRIM-HARD-SEEK] Android trimmed entry hard seek', {
-                    activeId,
-                    trimStart,
-                    localTime,
-                    timelineTime: time,
-                    targetTime,
-                    videoCurrentTime: activeEl.currentTime,
-                  });
-                }
+                entryState.didHardSeek = false;
                 if (
                   isTrimmedEntry
                   && !entryState.didRebaseClock
@@ -1080,7 +1060,7 @@ export function usePreviewEngine({
                   && !activeEl.seeking
                   && activeEl.videoWidth > 0
                   && activeEl.videoHeight > 0;
-                if (!isDrawablePlaying) {
+                if (!isDrawablePlaying && entryState.holdFrameCount < 3) {
                   holdAndroidPreviewFrame();
                   entryState.holdFrameCount += 1;
                 } else {
@@ -1144,11 +1124,7 @@ export function usePreviewEngine({
                     localTime,
                     trimStart,
                     drift: trimmedDrift,
-                    warmupExecuted: !!activeWarmupState?.warmupExecuted,
-                    warmupCompleted: !!activeWarmupState?.warmupCompleted,
                     preseekCompleted: !!preseekState?.completed,
-                    decoderWarmupCompleted: !!activeWarmupState?.decoderWarmupCompleted,
-                    preseeked: !!activeWarmupState?.preseeked,
                     activeReadyState: activeEl.readyState,
                     activePaused: activeEl.paused,
                     activeSeeking: activeEl.seeking,
@@ -1352,12 +1328,20 @@ export function usePreviewEngine({
 
         if (shouldClearCanvas) {
           const hasExplicitFadeToBlack = activeIndex !== -1 && !!currentItems[activeIndex]?.fadeOut;
+          const hasDrawableActiveVideo =
+            activeIndex !== -1
+            && currentItems[activeIndex]?.type === 'video'
+            && (() => {
+              const activeVideo = mediaElementsRef.current[currentItems[activeIndex].id] as HTMLVideoElement | undefined;
+              return !!activeVideo && activeVideo.readyState >= 2;
+            })();
           const shouldSuppressEndClear =
-            isActivePlaying
+            isAndroidPreviewPlayback
+            && isActivePlaying
             && !endFinalizedRef.current
             && totalDurationRef.current > 0
             && time < totalDurationRef.current
-            && !hasExplicitFadeToBlack;
+            && hasDrawableActiveVideo;
           if (shouldSuppressEndClear) {
             if (previewTimelineDiagnosticsRef.current.lastShouldSuppressEndClear !== true) {
               logInfo('RENDER', 'preview.endClear.suppressed', {
@@ -1394,196 +1378,7 @@ export function usePreviewEngine({
         }
 
         const nextVideoItem = findNextVideoItem(currentItems, activeIndex);
-
-        if (isActivePlaying && activeIndex !== -1 && nextVideoItem) {
-          const activeItem = currentItems[activeIndex];
-          const remainingTime = activeItem.duration - localTime;
-          if (remainingTime < 3.0) {
-            const nextElement = mediaElementsRef.current[nextVideoItem.id] as HTMLVideoElement;
-            if (nextElement) {
-              // localTime は通常 [0, duration] に収まるが、境界フォールバック時の揺れで
-              // 一時的に負側へ外れたフレームでは preseek を走らせない。
-              const shouldPreseekNextVideo =
-                isAndroidPreviewPlayback
-                && remainingTime >= 0
-                && remainingTime <= activeItem.duration
-                && nextVideoItem.type === 'video'
-                && (nextVideoItem.trimStart || 0) > 0;
-              const nextStart = nextVideoItem.trimStart || 0;
-              const warmupState = androidBoundaryWarmupRef.current[nextVideoItem.id]
-                ?? {
-                  targetStartSec: nextStart,
-                  preseeked: false,
-                  warmupExecuted: false,
-                  warmupCompleted: false,
-                  preseekCompleted: false,
-                  decoderWarmupCompleted: false,
-                  warmupStartAtSec: null,
-                  warmupAdvancedMs: 0,
-                };
-              if (Math.abs(warmupState.targetStartSec - nextStart) > 0.001) {
-                warmupState.targetStartSec = nextStart;
-                warmupState.preseeked = false;
-                warmupState.warmupExecuted = false;
-                warmupState.warmupCompleted = false;
-                warmupState.preseekCompleted = false;
-                warmupState.decoderWarmupCompleted = false;
-                warmupState.warmupStartAtSec = null;
-                warmupState.warmupAdvancedMs = 0;
-                logInfo('RENDER', 'preview.warmup.cancelled', {
-                  nextId: nextVideoItem.id,
-                  reason: 'target_changed',
-                  targetStartSec: nextStart,
-                });
-              }
-              androidBoundaryWarmupRef.current[nextVideoItem.id] = warmupState;
-              const preseekState = androidTrimPreseekRef.current[nextVideoItem.id];
-              const alreadyRequestedSameTarget = !!preseekState
-                && Math.abs(preseekState.targetTime - nextStart) <= 0.001;
-              if (nextElement.readyState === 0 && !nextElement.error) {
-                try { nextElement.load(); } catch { /* ignore */ }
-              }
-              if (
-                shouldPreseekNextVideo
-                && !alreadyRequestedSameTarget
-                && !nextElement.seeking
-                && nextElement.readyState >= MIN_VIDEO_READY_STATE_FOR_SEEK
-                && Math.abs(nextElement.currentTime - nextStart)
-                > PREVIEW_ANDROID_TRIMMED_VIDEO_SYNC_TOLERANCE_SEC
-              ) {
-                nextElement.currentTime = nextStart;
-                androidTrimPreseekRef.current[nextVideoItem.id] = {
-                  targetTime: nextStart,
-                  requestedAt: Date.now(),
-                  completed: false,
-                  firstAdvancedAtSec: null,
-                };
-                logInfo('RENDER', '[DIAG-TRIM-PRESEEK] next trimmed video preseek', {
-                  activeId,
-                  nextId: nextVideoItem.id,
-                  trimStart: nextStart,
-                  remainingSec: remainingTime,
-                  readyState: nextElement.readyState,
-                  seeking: nextElement.seeking,
-                  paused: nextElement.paused,
-                  currentTime: nextElement.currentTime,
-                });
-                warmupState.preseeked = true;
-                warmupState.preseekCompleted = false;
-                logInfo('RENDER', '[DIAG-BOUNDARY-WARMUP] next video preseek requested', {
-                  activeId,
-                  nextId: nextVideoItem.id,
-                  remainingSec: remainingTime,
-                  targetStartSec: nextStart,
-                  readyState: nextElement.readyState,
-                  paused: nextElement.paused,
-                  seeking: nextElement.seeking,
-                  preseeked: warmupState.preseeked,
-                });
-                logInfo('RENDER', 'preview.warmup.schedule', {
-                  activeId,
-                  nextId: nextVideoItem.id,
-                  remainingSec: remainingTime,
-                  targetStartSec: nextStart,
-                });
-              }
-              if (
-                isAndroidPreviewPlayback
-                && remainingTime <= 0.50
-                && remainingTime >= 0
-                && !warmupState.warmupCompleted
-                && !!preseekState?.completed
-                && nextElement.readyState >= MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME
-                && !nextElement.seeking
-              ) {
-                const warmupLeadTimeSec = Math.min(0.50, Math.max(0, remainingTime));
-                const warmupTarget = Math.max(0, nextStart - warmupLeadTimeSec);
-                try {
-                  if (!warmupState.warmupExecuted) {
-                    logInfo('RENDER', 'preview.warmup.start', {
-                      activeId,
-                      nextId: nextVideoItem.id,
-                      remainingSec: remainingTime,
-                      warmupTargetSec: warmupTarget,
-                      warmupLeadTimeSec,
-                    });
-                  }
-                  warmupState.warmupExecuted = true;
-                  nextElement.muted = true;
-                  nextElement.defaultMuted = true;
-                  nextElement.playsInline = true;
-                  if (warmupState.warmupStartAtSec === null) {
-                    if (Math.abs(nextElement.currentTime - warmupTarget) > 0.03) {
-                      nextElement.currentTime = warmupTarget;
-                    }
-                    warmupState.warmupStartAtSec = nextElement.currentTime;
-                  }
-                  void nextElement.play().then(() => {
-                    logInfo('RENDER', 'preview.warmup.playResolved', {
-                      nextId: nextVideoItem.id,
-                      paused: nextElement.paused,
-                      readyState: nextElement.readyState,
-                    });
-                  }).catch(() => undefined);
-                  const warmupAdvancedMs = warmupState.warmupStartAtSec === null
-                    ? 0
-                    : Math.max(0, (nextElement.currentTime - warmupState.warmupStartAtSec) * 1000);
-                  warmupState.warmupAdvancedMs = warmupAdvancedMs;
-                  logInfo('RENDER', 'preview.warmup.currentTimeAdvanced', {
-                    nextId: nextVideoItem.id,
-                    warmupAdvancedMs,
-                    currentTime: nextElement.currentTime,
-                    warmupStartAtSec: warmupState.warmupStartAtSec,
-                  });
-                  if (
-                    warmupAdvancedMs >= 80
-                    && !nextElement.paused
-                    && !nextElement.seeking
-                    && nextElement.readyState >= MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME
-                  ) {
-                    warmupState.warmupCompleted = true;
-                    warmupState.preseekCompleted = true;
-                    warmupState.decoderWarmupCompleted = true;
-                    logInfo('RENDER', 'preview.warmup.completed', {
-                      nextId: nextVideoItem.id,
-                      warmupAdvancedMs,
-                    });
-                  }
-                } catch {
-                  // ignore
-                }
-              }
-              if (preseekState) {
-                const preseekDrift = Math.abs(nextElement.currentTime - preseekState.targetTime);
-                const hasFirstFrame = nextElement.videoWidth > 0 && nextElement.videoHeight > 0;
-                const advancedSec = nextElement.currentTime - preseekState.targetTime;
-                if (advancedSec > 0.005 && preseekState.firstAdvancedAtSec === null) {
-                  preseekState.firstAdvancedAtSec = nextElement.currentTime;
-                }
-                const currentTimeAdvancedMs = preseekState.firstAdvancedAtSec === null
-                  ? 0
-                  : Math.max(0, (nextElement.currentTime - preseekState.firstAdvancedAtSec) * 1000);
-                const basePreseekReady =
-                  nextElement.readyState >= 3
-                  && !nextElement.seeking
-                  && preseekDrift <= 0.12
-                  && hasFirstFrame;
-                const progressedWhilePlaying =
-                  !nextElement.paused
-                  && currentTimeAdvancedMs >= 80;
-                if (basePreseekReady && (nextElement.paused || progressedWhilePlaying)) {
-                  preseekState.completed = true;
-                  warmupState.preseekCompleted = true;
-                }
-              }
-              if (!shouldPreseekNextVideo && (nextElement.paused || nextElement.readyState < 2)) {
-                if (Math.abs(nextElement.currentTime - nextStart) > 0.1) {
-                  nextElement.currentTime = nextStart;
-                }
-              }
-            }
-          }
-        }
+        // Emergency fix: Android preview boundary preroll/warmup/preseek is intentionally disabled.
 
         const allowExtendedFutureVideoPrewarm = !activeId || currentItems[activeIndex]?.type !== 'video';
         let nearestFutureVideoId: string | null = null;
@@ -3310,32 +3105,7 @@ export function usePreviewEngine({
           ? mediaElementsRef.current[nextVideoItem.id] as HTMLVideoElement | undefined
           : undefined;
         const nextTrimStart = nextVideoItem?.trimStart || 0;
-        const nextPrerollTarget = Math.max(0, nextTrimStart - 0.35);
-        let nextPrerollArmed = false;
-        if (
-          platformCapabilities.isAndroid
-          && !platformCapabilities.isIosSafari
-          && !isExportMode
-          && nextVideoElForPreflight
-        ) {
-          try {
-            nextVideoElForPreflight.defaultMuted = true;
-            nextVideoElForPreflight.muted = true;
-            nextVideoElForPreflight.playsInline = true;
-            if (nextVideoElForPreflight.readyState === 0) nextVideoElForPreflight.load();
-            if (Math.abs(nextVideoElForPreflight.currentTime - nextPrerollTarget) > 0.03) {
-              nextVideoElForPreflight.currentTime = nextPrerollTarget;
-            }
-            await nextVideoElForPreflight.play();
-            nextPrerollArmed = true;
-          } catch {
-            logWarn('RENDER', 'preview.android.preroll.warning', {
-              nextVideoId: nextVideoItem?.id ?? null,
-              nextTrimStartSec: nextTrimStart,
-              prerollTargetSec: nextPrerollTarget,
-            });
-          }
-        }
+        const nextPrerollArmed = false;
         const nextVideoReadyState = nextVideoElForPreflight?.readyState ?? null;
         const nextVideoDrift = nextVideoElForPreflight
           ? Math.abs(nextVideoElForPreflight.currentTime - nextTrimStart)

--- a/src/test/standardInactiveVideoManager.test.tsx
+++ b/src/test/standardInactiveVideoManager.test.tsx
@@ -104,7 +104,7 @@ describe('standard inactive video manager', () => {
 
     expect(nextVideoElement.pause).toHaveBeenCalledTimes(1);
     expect(nextVideoElement.currentTime).toBeCloseTo(nextVideo.trimStart ?? 0);
-    expect(farVideoElement.pause).toHaveBeenCalledTimes(1);
+    expect(farVideoElement.pause).toHaveBeenCalledTimes(0);
     expect(farVideoElement.currentTime).toBeCloseTo(4.2);
   });
 

--- a/src/test/standardPreviewEngine.test.tsx
+++ b/src/test/standardPreviewEngine.test.tsx
@@ -844,7 +844,7 @@ describe('standard preview engine', () => {
     expect(didUpdateCanvas).toBe(false);
   });
 
-  it('Android preview は video -> trimmed video の先頭でも currentTime を合わせて描画を hold する', () => {
+  it('Android preview は video -> trimmed video の先頭で hard seek せず描画 hold を優先する', () => {
     const leadVideo = createVideoItem({
       id: 'video-1',
       duration: 1,
@@ -876,16 +876,15 @@ describe('standard preview engine', () => {
     });
 
     const timelineTime = 1.2;
-    const expectedTime = trimmedVideo.trimStart + (timelineTime - leadVideo.duration);
     const didUpdateCanvas = hook.result.current.renderFrame(timelineTime, true, false);
 
-    expect(trimmedVideoElement.currentTime).toBeCloseTo(expectedTime);
+    expect(trimmedVideoElement.currentTime).toBeCloseTo(1.7);
     expect(canvasContext.fillRect).not.toHaveBeenCalled();
     expect(canvasContext.drawImage).not.toHaveBeenCalled();
     expect(didUpdateCanvas).toBe(false);
   });
 
-  it('Android preview は clip 終端 0.8 秒だけ次の video を trimStart に preseek する', () => {
+  it('Android preview は clip 境界前でも次の video を preseek しない', () => {
     const imageItem = createImageItem({ id: 'image-gap', duration: 1 });
     const videoItem = createVideoItem({
       id: 'video-2',
@@ -908,7 +907,7 @@ describe('standard preview engine', () => {
 
     hook.result.current.renderFrame(0.75, true, false);
 
-    expect(videoElement.currentTime).toBeCloseTo(videoItem.trimStart);
+    expect(videoElement.currentTime).toBeCloseTo(0.2);
   });
 
   it('Android preview の next video preseek は trimStart=0 では発火しない', () => {
@@ -947,7 +946,7 @@ describe('standard preview engine', () => {
     expect(videoElement.currentTime).toBeCloseTo(0.4);
   });
 
-  it('Android preview の next video preseek は image gap を挟んでも直近の次 video だけを対象にする', () => {
+  it('Android preview の next video preseek は image gap を挟むケースでも無効のままにする', () => {
     const currentVideo = createVideoItem({
       id: 'video-1',
       duration: 1,
@@ -996,11 +995,11 @@ describe('standard preview engine', () => {
 
     hook.result.current.renderFrame(0.5, true, false);
 
-    expect(nextVideoElement.currentTime).toBeCloseTo(nextVideo.trimStart);
+    expect(nextVideoElement.currentTime).toBeCloseTo(0.1);
     expect(farVideoElement.currentTime).toBeCloseTo(0.2);
   });
 
-  it('Android preview の next trimmed video preseek は clip 開始直後から発火する', () => {
+  it('Android preview の next trimmed video preseek は clip 開始直後でも発火しない', () => {
     const imageItem = createImageItem({ id: 'image-gap', duration: 1 });
     const videoItem = createVideoItem({
       id: 'video-2',
@@ -1023,10 +1022,10 @@ describe('standard preview engine', () => {
 
     hook.result.current.renderFrame(0.19, true, false);
 
-    expect(videoElement.currentTime).toBeCloseTo(videoItem.trimStart);
+    expect(videoElement.currentTime).toBeCloseTo(0.2);
   });
 
-  it('Android preview の next trimmed video preseek は同じ trimStart へ連続発火しない', () => {
+  it('Android preview の next trimmed video preseek は無効化され currentTime を連続変更しない', () => {
     const imageItem = createImageItem({ id: 'image-gap', duration: 1 });
     const videoItem = createVideoItem({
       id: 'video-2',
@@ -1059,11 +1058,11 @@ describe('standard preview engine', () => {
     hook.result.current.renderFrame(0.75, true, false);
     hook.result.current.renderFrame(0.76, true, false);
 
-    expect(assignedCurrentTime).toBeCloseTo(videoItem.trimStart);
-    expect(seekAssignCount).toBe(1);
+    expect(assignedCurrentTime).toBeCloseTo(0.2);
+    expect(seekAssignCount).toBe(0);
   });
 
-  it('Android preview の next trimmed video preseek は metadata 未取得や seeking 中には currentTime を動かさない', () => {
+  it('Android preview の next trimmed video preseek 無効化後も metadata 未取得や seeking 中に currentTime を動かさない', () => {
     const imageItem = createImageItem({ id: 'image-gap', duration: 1 });
     const videoItem = createVideoItem({
       id: 'video-2',
@@ -1087,7 +1086,7 @@ describe('standard preview engine', () => {
 
     notReadyHarness.hook.result.current.renderFrame(0.75, true, false);
 
-    expect(notReadyVideo.load).toHaveBeenCalledTimes(1);
+    expect(notReadyVideo.load).toHaveBeenCalledTimes(0);
     expect(notReadyVideo.currentTime).toBeCloseTo(0.2);
 
     const seekingVideo = createMockVideoElement();


### PR DESCRIPTION
### Motivation
- Android Chrome のプレビュー境界で warmup/preroll/hard-seek 系が組み合わさり境界で動画が固まる・seeking/readyState の不正遷移が発生していたため、まず再生不正を完全に止めるために該当経路を通常再生から切り離す緊急止血を行った。 
- 目的は滑らかさの追求ではなく「境界で再生が壊れる事象をゼロにする」ことである。 
- 対応は Android preview に限定し、iOS Safari / export 経路には波及させない方針で実施した（使用スキル: `bugfix-guard`, `turtle-video-overview` を参照してデグレ防止を意識）。

### Description
- `src/flavors/standard/preview/usePreviewEngine.ts` の Android preview 境界経路から free-running preroll/warmup/preseek/hard-seek を無効化し、`nextPrerollArmed` を常に `false` とした。 
- trimmed-entry 境界での強制 `currentTime` 補正（hard seek）を行わないようにし、`entryState.didHardSeek` を false 扱いに変更して hard seek 分岐を無効化した。 
- holdFrame の連続発動を抑制するため `holdFrameCount` の継続上限を 3 未満に制限し、hold 中の hard seek / clear を発生させないようにした。 
- `preview.trimmedEntry.preseekMiss` 等の診断ログから warmup 依存状態の再生分岐参照を外し、境界判定を実動画状態優先に簡素化した。 
- 再生中の `preview.endClear.executed` を発生させない抑止条件を強化し、Android preview 再生中で描画可能な active video がある場合は endClear を実行しないよう変更した。 
- 境界向け warmup/preseek ブロックは emergency fix として通常の再生ループ分岐からコメント化／除外し、追加パッチは極力積まない形で止血を優先した。 
- 上記仕様変更に合わせ、Android 境界前提の既存ユニットテストの期待値を今回の方針に合わせて更新した（対象テストファイルの期待動作を preseek 無効化・hard-seek 無効化に変更）。

### Testing
- フルテスト実行で事象を確認するため `npm run test:run` を実行したところ、当初は Android preseek/warmup 前提のテストが失敗したため該当テストを今回の挙動に合わせて修正した（自動テストの期待値更新）。
- 修正後、対象ユニットのみで `npm run test:run -- src/test/standardPreviewEngine.test.tsx src/test/standardInactiveVideoManager.test.tsx` を実行し、両ファイルのテストが合格（計 23 テストすべて成功）。
- ビルド確認として `npm run build` を実行し、TypeScript コンパイルと Vite ビルドが成功した。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5c08e73b88325857c6c354dbd66f3)