### PR TITLE
fix: preview engine型契約をstandard flavorに合わせて同期

### DIFF
--- a/.agents/skills/turtle-video-overview/references/implementation-patterns.md
+++ b/.agents/skills/turtle-video-overview/references/implementation-patterns.md
@@ -1845,3 +1845,13 @@
 - **注意点**:
   - free-running preroll / hard seek / visual bridge 復活や holdFrame 許容拡大で隠蔽しない。
   - Android preview 専用条件に閉じ、export/iOS/通常 preview の reset 挙動を変えない。
+
+### 13-95. Preview runtime の `usePreviewEngine` 契約は flavor 間で同期する
+
+- **ファイル**: `src/components/turtle-video/usePreviewEngine.ts`, `src/flavors/standard/preview/usePreviewEngine.ts`, `src/components/TurtleVideo.tsx`
+- **問題**:
+  - standard flavor 側で `setPreviewPlaying` を必須パラメータに追加したあと、ベース runtime 側の `UsePreviewEngineParams` が未更新だと、`PreviewRuntime` の関数型が不一致になり CI の `tsc` が失敗する。
+- **対策**:
+  - runtime 契約として使っているベース側 `UsePreviewEngineParams` にも同じ `setPreviewPlaying` を追加し、`previewRuntime.usePreviewEngine(...)` の呼び出しオブジェクトと整合させる。
+- **注意点**:
+  - flavor 実装だけ更新しても型契約が分岐して破綻するため、`usePreviewEngine` の引数追加時はベース/標準の両実装を同時に点検する。

--- a/src/components/turtle-video/usePreviewEngine.ts
+++ b/src/components/turtle-video/usePreviewEngine.ts
@@ -90,6 +90,7 @@ interface UsePreviewEngineParams {
   setVideoDuration: (id: string, duration: number) => void;
   setCurrentTime: (time: number) => void;
   setProcessing: (processing: boolean) => void;
+  setPreviewPlaying: (playing: boolean) => void;
   setLoading: (loading: boolean) => void;
   setExportPreparationStep: (step: ExportPreparationStep | null) => void;
   setExportUrl: (url: string | null) => void;


### PR DESCRIPTION
### Motivation
- standard flavor 側で `usePreviewEngine` に `setPreviewPlaying` を導入したことで、ベース runtime の引数型が不整合になり TypeScript ビルドエラー（TS2353 / TS2719）が発生していたため、型契約を同期してビルドを通す必要がありました（対応時に `bugfix-guard` と `turtle-video-overview` スキルを参照して影響範囲を確認しました）。

### Description
- ベース runtime 側の `UsePreviewEngineParams`（`src/components/turtle-video/usePreviewEngine.ts`）に `setPreviewPlaying: (playing: boolean) => void;` を追加して、`previewRuntime.usePreviewEngine(...)` 呼び出しと型を整合させました。
- 再発防止のためにオーバービュー資料（`.agents/skills/turtle-video-overview/references/implementation-patterns.md`）へ「flavor 間で `usePreviewEngine` 契約を同期する」運用注意を追記しました。

### Testing
- `npm run build`（`tsc && vite build`）を実行し、TypeScript コンパイルおよび Vite ビルドが正常に完了することを確認しました（ビルド成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6b22667648325b146e7b58e09ab5e)