### PR TITLE
feat: エクスポート画質を改善（動的キャンバスサイズ＋高ビットレート）

### DIFF
--- a/src/components/TurtleVideo.tsx
+++ b/src/components/TurtleVideo.tsx
@@ -12,8 +12,6 @@ import type { SectionHelpKey } from '../constants/sectionHelp';
 import type { PreviewRuntime } from './turtle-video/previewRuntime';
 import type { SaveRuntime } from './turtle-video/saveRuntime';
 import {
-  CANVAS_WIDTH,
-  CANVAS_HEIGHT,
   VOICE_OPTIONS,
   GEMINI_API_BASE_URL,
   GEMINI_SCRIPT_MODEL,
@@ -21,6 +19,7 @@ import {
   GEMINI_TTS_MODEL,
   TTS_SAMPLE_RATE,
 } from '../constants';
+import { useCanvasStore } from '../stores/canvasStore';
 
 import type { ExportPreparationStep } from '../hooks/useExport';
 import { usePreventUnload } from '../hooks/usePreventUnload';
@@ -80,6 +79,12 @@ const TurtleVideo: React.FC<TurtleVideoProps> = ({ appFlavor, previewRuntime, ex
   usePreventUnload();
 
   // === Zustand Stores ===
+  // Canvas Store (動的キャンバスサイズ)
+  const canvasWidth = useCanvasStore((s) => s.width);
+  const canvasHeight = useCanvasStore((s) => s.height);
+  const resetCanvasSize = useCanvasStore((s) => s.resetCanvasSize);
+  const applyCanvasFromSource = useCanvasStore((s) => s.applyFromSource);
+
   // Media Store
   const mediaItems = useMediaStore((s) => s.mediaItems);
   const totalDuration = useMediaStore((s) => s.totalDuration);
@@ -354,11 +359,11 @@ const TurtleVideo: React.FC<TurtleVideoProps> = ({ appFlavor, previewRuntime, ex
       narrations,
       captions,
       captionSettings,
-      canvasWidth: CANVAS_WIDTH,
-      canvasHeight: CANVAS_HEIGHT,
+      canvasWidth,
+      canvasHeight,
       fps: 30,
     }),
-    [bgm, captionSettings, captions, mediaItems, narrations],
+    [bgm, captionSettings, captions, mediaItems, narrations, canvasWidth, canvasHeight],
   );
   const supportsShowSaveFilePicker = platformCapabilities.supportsShowSaveFilePicker;
   const supportsShowOpenFilePicker = platformCapabilities.supportsShowOpenFilePicker;
@@ -400,6 +405,19 @@ const TurtleVideo: React.FC<TurtleVideoProps> = ({ appFlavor, previewRuntime, ex
     setEditingNarrationId(null);
     closeAiModal();
   }, [offlineMode, showAiModal, closeAiModal]);
+
+  // --- 動的キャンバスサイズ: 最初のビデオメディアの解像度に応じて
+  // エクスポート用キャンバスサイズを更新する（1920×1080 上限、横向き固定）。
+  useEffect(() => {
+    const firstVideo = mediaItems.find((item) => item.type === 'video');
+    if (!firstVideo) {
+      resetCanvasSize();
+      return;
+    }
+    if (firstVideo.sourceWidth && firstVideo.sourceHeight) {
+      applyCanvasFromSource(firstVideo.sourceWidth, firstVideo.sourceHeight);
+    }
+  }, [mediaItems, resetCanvasSize, applyCanvasFromSource]);
 
   // --- メモリ監視（10秒ごと） ---
   useEffect(() => {
@@ -1766,9 +1784,9 @@ const TurtleVideo: React.FC<TurtleVideoProps> = ({ appFlavor, previewRuntime, ex
     if (canvasRef.current) {
       const ctx = canvasRef.current.getContext('2d');
       if (ctx) {
-        ctx.clearRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+        ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
         ctx.fillStyle = '#000000';
-        ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+        ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
       }
     }
   }, [mediaItems, bgm, narrations, stopAll, clearAllMedia, clearAllAudio, resetCaptions, resetUI]);
@@ -2153,13 +2171,13 @@ const TurtleVideo: React.FC<TurtleVideoProps> = ({ appFlavor, previewRuntime, ex
     position: 'fixed',
     top: 0,
     left: 0,
-    width: `${CANVAS_WIDTH}px`,
-    height: `${CANVAS_HEIGHT}px`,
+    width: `${canvasWidth}px`,
+    height: `${canvasHeight}px`,
     opacity: 0.001,
     pointerEvents: 'none',
     zIndex: -100,
     visibility: 'visible',
-  }), []);
+  }), [canvasWidth, canvasHeight]);
 
   return (
     <div className="min-h-screen bg-gray-950 text-gray-100 font-sans pb-24 select-none relative">

--- a/src/components/common/MiniPreview.tsx
+++ b/src/components/common/MiniPreview.tsx
@@ -5,6 +5,7 @@
  */
 import React, { useRef, useEffect, useCallback } from 'react';
 import type { MediaItem } from '../../types';
+import { useCanvasStore } from '../../stores/canvasStore';
 
 interface MiniPreviewProps {
   item: MediaItem;
@@ -13,13 +14,13 @@ interface MiniPreviewProps {
 
 const MINI_CANVAS_WIDTH = 96;
 const MINI_CANVAS_HEIGHT = 54;
-const ORIGINAL_WIDTH = 1280;
 
 /**
  * ミニプレビューコンポーネント
  * トランスフォームパネル内に埋め込み表示
  */
 const MiniPreview: React.FC<MiniPreviewProps> = ({ item, mediaElement }) => {
+  const projectCanvasWidth = useCanvasStore((s) => s.width);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const animationRef = useRef<number | null>(null);
@@ -53,7 +54,7 @@ const MiniPreview: React.FC<MiniPreviewProps> = ({ item, mediaElement }) => {
     ctx.fillRect(0, 0, MINI_CANVAS_WIDTH, MINI_CANVAS_HEIGHT);
 
     // スケール比率 (プレビュー枠サイズ / オリジナルサイズ)
-    const previewRatio = MINI_CANVAS_WIDTH / ORIGINAL_WIDTH;
+    const previewRatio = MINI_CANVAS_WIDTH / projectCanvasWidth;
 
     // メディアの元サイズを取得
     let elemW = 0;
@@ -104,7 +105,7 @@ const MiniPreview: React.FC<MiniPreviewProps> = ({ item, mediaElement }) => {
     ctx.strokeStyle = 'rgba(255, 255, 255, 0.3)';
     ctx.lineWidth = 1;
     ctx.strokeRect(0, 0, MINI_CANVAS_WIDTH, MINI_CANVAS_HEIGHT);
-  }, [mediaElement]); // itemへの依存を削除
+  }, [mediaElement, projectCanvasWidth]); // itemへの依存を削除
 
   useEffect(() => {
     itemRef.current = item;

--- a/src/components/media/ClipItem.tsx
+++ b/src/components/media/ClipItem.tsx
@@ -27,6 +27,7 @@ import type { MediaItem } from '../../types';
 import MiniPreview from '../common/MiniPreview';
 import ClipThumbnail from '../common/ClipThumbnail';
 import { SwipeProtectedSlider } from '../SwipeProtectedSlider';
+import { useCanvasStore } from '../../stores/canvasStore';
 
 export interface ClipItemProps {
   item: MediaItem;
@@ -82,6 +83,8 @@ const ClipItem: React.FC<ClipItemProps> = ({
   onUpdateFadeOutDuration,
 }) => {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const canvasWidth = useCanvasStore((s) => s.width);
+  const canvasHeight = useCanvasStore((s) => s.height);
   const isDisabled = isClipsLocked || v.isLocked;
 
   // スワイプ保護用コールバック
@@ -330,8 +333,8 @@ const ClipItem: React.FC<ClipItemProps> = ({
               </button>
             </div>
             <SwipeProtectedSlider
-              min={-1280}
-              max={1280}
+              min={-canvasWidth}
+              max={canvasWidth}
               step={10}
               value={v.positionX || 0}
               onChange={handlePositionX}
@@ -356,8 +359,8 @@ const ClipItem: React.FC<ClipItemProps> = ({
               </button>
             </div>
             <SwipeProtectedSlider
-              min={-720}
-              max={720}
+              min={-canvasHeight}
+              max={canvasHeight}
               step={10}
               value={v.positionY || 0}
               onChange={handlePositionY}

--- a/src/components/modals/SaveLoadModal.tsx
+++ b/src/components/modals/SaveLoadModal.tsx
@@ -25,7 +25,7 @@ import {
   setAutoSaveInterval,
   type AutoSaveIntervalOption,
 } from '../../hooks/useAutoSave';
-import { CANVAS_WIDTH, CANVAS_HEIGHT } from '../../constants';
+import { useCanvasStore } from '../../stores/canvasStore';
 import { useDisableBodyScroll } from '../../hooks/useDisableBodyScroll';
 import type { ProjectPersistenceHealthSnapshot } from '../../stores/projectPersistenceHealth';
 
@@ -133,6 +133,8 @@ function getSaveFailureCategoryLabel(category: SaveFailureCategory | undefined):
 }
 
 export default function SaveLoadModal({ isOpen, onClose, onToast, onBeforeLoadProject, appFlavor, saveRuntime }: SaveLoadModalProps) {
+  const canvasWidth = useCanvasStore((s) => s.width);
+  const canvasHeight = useCanvasStore((s) => s.height);
   const [mode, setMode] = useState<ModalMode>('menu');
   const [selectedSlot, setSelectedSlot] = useState<SaveSlot | null>(null);
   const [autoSaveInterval, setAutoSaveIntervalState] = useState<AutoSaveIntervalOption>(getAutoSaveInterval);
@@ -423,17 +425,17 @@ export default function SaveLoadModal({ isOpen, onClose, onToast, onBeforeLoadPr
    */
   const handleGenerateColorImage = (color: 'black' | 'white') => {
     const canvas = document.createElement('canvas');
-    canvas.width = CANVAS_WIDTH;
-    canvas.height = CANVAS_HEIGHT;
+    canvas.width = canvasWidth;
+    canvas.height = canvasHeight;
     const ctx = canvas.getContext('2d');
     if (!ctx) {
       onToast('画像の生成に失敗しました', 'error');
       return;
     }
-    
+
     ctx.fillStyle = color === 'black' ? '#000000' : '#FFFFFF';
-    ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
-    
+    ctx.fillRect(0, 0, canvasWidth, canvasHeight);
+
     // PNGとしてダウンロード
     canvas.toBlob(async (blob) => {
       if (!blob) {
@@ -445,14 +447,14 @@ export default function SaveLoadModal({ isOpen, onClose, onToast, onBeforeLoadPr
         const result = await saveRuntime.saveBlobWithClientFileStrategy({
           blob,
           descriptor: {
-            filename: `${color === 'black' ? '黒' : '白'}画像_${CANVAS_WIDTH}x${CANVAS_HEIGHT}.png`,
+            filename: `${color === 'black' ? '黒' : '白'}画像_${canvasWidth}x${canvasHeight}.png`,
             mimeType: 'image/png',
             description: 'PNG 画像',
           },
           supportsShowSaveFilePicker,
         });
 
-        useLogStore.getState().info('MEDIA', `${color === 'black' ? '黒' : '白'}画像を生成 (${CANVAS_WIDTH}x${CANVAS_HEIGHT})`, {
+        useLogStore.getState().info('MEDIA', `${color === 'black' ? '黒' : '白'}画像を生成 (${canvasWidth}x${canvasHeight})`, {
           saveStrategy: result.strategy,
         });
         onToast(
@@ -723,7 +725,7 @@ export default function SaveLoadModal({ isOpen, onClose, onToast, onBeforeLoadPr
                   <div className="space-y-1.5">
                     <div className="font-semibold text-orange-100">素材</div>
                     <ul className="list-disc ml-4 space-y-1">
-                      <li>素材生成では 1280x720 の黒画像・白画像を作成できます。</li>
+                      <li>素材生成では現在のプロジェクトキャンバスサイズに合わせた黒画像・白画像を作成できます。</li>
                       <li>動画のつなぎや背景用のプレースホルダー素材として利用できます。</li>
                     </ul>
                   </div>
@@ -916,7 +918,7 @@ export default function SaveLoadModal({ isOpen, onClose, onToast, onBeforeLoadPr
               <div className="flex items-center gap-2 mb-3">
                 <Image size={14} className="text-gray-400" />
                 <span className="text-sm text-gray-400">素材生成</span>
-                <span className="text-xs text-gray-500">({CANVAS_WIDTH}×{CANVAS_HEIGHT}px)</span>
+                <span className="text-xs text-gray-500">({canvasWidth}×{canvasHeight}px)</span>
               </div>
               <div className="flex gap-2">
                 <button

--- a/src/components/sections/PreviewSection.tsx
+++ b/src/components/sections/PreviewSection.tsx
@@ -21,6 +21,7 @@ import type { ExportPreparationStep } from '../../hooks/useExport';
 import type { AppFlavor } from '../../app/resolveAppFlavor';
 import { getPreviewRuntimeNotice } from '../../app/appFlavorUi';
 import { useLogStore } from '../../stores/logStore';
+import { useCanvasStore } from '../../stores/canvasStore';
 
 const PREVIEW_ICON_BUTTON_BASE =
   'relative overflow-hidden p-3 lg:p-4 rounded-full border transition-[transform,background-color,color,box-shadow,filter] duration-200 shadow-lg active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed';
@@ -130,6 +131,8 @@ const PreviewSection: React.FC<PreviewSectionProps> = ({
   formatTime,
 }) => {
   const log = useLogStore.getState();
+  const canvasWidth = useCanvasStore((s) => s.width);
+  const canvasHeight = useCanvasStore((s) => s.height);
   const [exportPhase, setExportPhase] = useState<ExportPhase>('preparing');
   const [isCapturePressed, setIsCapturePressed] = useState(false);
   const lastObservedTimeRef = useRef<number>(currentTime);
@@ -377,8 +380,8 @@ const PreviewSection: React.FC<PreviewSectionProps> = ({
       <div className="relative aspect-video bg-black w-full group">
         <canvas
           ref={canvasRef}
-          width={1280}
-          height={720}
+          width={canvasWidth}
+          height={canvasHeight}
           className="w-full h-full object-contain"
         />
         {mediaItems.length === 0 && (

--- a/src/components/sections/PreviewSection.tsx
+++ b/src/components/sections/PreviewSection.tsx
@@ -3,7 +3,7 @@
  * @author Turtle Village
  * @description 編集中の動画をリアルタイムでプレビュー再生、シーク、およびファイルへの書き出しを行うセクションコンポーネント。
  */
-import React, { RefObject, useEffect, useMemo, useRef, useState } from 'react';
+import React, { RefObject, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import {
   Play,
   Pause,
@@ -133,6 +133,18 @@ const PreviewSection: React.FC<PreviewSectionProps> = ({
   const log = useLogStore.getState();
   const canvasWidth = useCanvasStore((s) => s.width);
   const canvasHeight = useCanvasStore((s) => s.height);
+  // canvas.width / canvas.height をセットすると内容がクリアされるので、
+  // 実際にサイズが変わるときだけ書き換える（毎レンダリングでの再代入を避ける）。
+  useLayoutEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    if (canvas.width !== canvasWidth) {
+      canvas.width = canvasWidth;
+    }
+    if (canvas.height !== canvasHeight) {
+      canvas.height = canvasHeight;
+    }
+  }, [canvasWidth, canvasHeight, canvasRef]);
   const [exportPhase, setExportPhase] = useState<ExportPhase>('preparing');
   const [isCapturePressed, setIsCapturePressed] = useState(false);
   const lastObservedTimeRef = useRef<number>(currentTime);
@@ -380,8 +392,6 @@ const PreviewSection: React.FC<PreviewSectionProps> = ({
       <div className="relative aspect-video bg-black w-full group">
         <canvas
           ref={canvasRef}
-          width={canvasWidth}
-          height={canvasHeight}
           className="w-full h-full object-contain"
         />
         {mediaItems.length === 0 && (

--- a/src/components/turtle-video/usePreviewEngine.ts
+++ b/src/components/turtle-video/usePreviewEngine.ts
@@ -1,8 +1,6 @@
 import { useCallback, type MutableRefObject } from 'react';
 
 import {
-  CANVAS_HEIGHT,
-  CANVAS_WIDTH,
   FPS,
 } from '../../constants';
 import type {
@@ -265,6 +263,9 @@ export function usePreviewEngine({
         const duration = videoEl.duration;
         if (!isNaN(duration) && duration !== Infinity) {
           setVideoDuration(id, duration);
+          if (videoEl.videoWidth > 0 && videoEl.videoHeight > 0) {
+            useMediaStore.getState().setMediaSourceDimensions(id, videoEl.videoWidth, videoEl.videoHeight);
+          }
           logInfo('MEDIA', `ビデオロード完了: ${id.substring(0, 8)}...`, {
             duration: Math.round(duration * 10) / 10,
             readyState: videoEl.readyState,
@@ -641,7 +642,7 @@ export function usePreviewEngine({
           }
           ctx.globalAlpha = 1.0;
           ctx.fillStyle = '#000000';
-          ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+          ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
           didUpdateCanvas = true;
         }
 
@@ -831,10 +832,10 @@ export function usePreviewEngine({
                 const userX = conf.positionX || 0;
                 const userY = conf.positionY || 0;
 
-                const baseScale = Math.min(CANVAS_WIDTH / elemW, CANVAS_HEIGHT / elemH);
+                const baseScale = Math.min(ctx.canvas.width / elemW, ctx.canvas.height / elemH);
 
                 ctx.save();
-                ctx.translate(CANVAS_WIDTH / 2 + userX, CANVAS_HEIGHT / 2 + userY);
+                ctx.translate(ctx.canvas.width / 2 + userX, ctx.canvas.height / 2 + userY);
                 ctx.scale(baseScale * scaleFactor, baseScale * scaleFactor);
 
                 let alpha = 1.0;
@@ -1030,9 +1031,9 @@ export function usePreviewEngine({
             if (effectivePosition === 'top') {
               y = padding + fontSize / 2;
             } else if (effectivePosition === 'center') {
-              y = CANVAS_HEIGHT / 2;
+              y = ctx.canvas.height / 2;
             } else {
-              y = CANVAS_HEIGHT - padding - fontSize / 2;
+              y = ctx.canvas.height - padding - fontSize / 2;
             }
 
             const captionDuration = activeCaption.endTime - activeCaption.startTime;
@@ -1072,7 +1073,7 @@ export function usePreviewEngine({
             ctx.textBaseline = 'middle';
 
             const blurStrength = Math.max(0, currentCaptionSettings.blur);
-            const centerX = CANVAS_WIDTH / 2;
+            const centerX = ctx.canvas.width / 2;
             const drawCaptionGlyph = (
               x: number,
               yPos: number,

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -6,14 +6,16 @@
 import type { VoiceOption } from '../types';
 
 // キャンバス設定
-// CANVAS_WIDTH / CANVAS_HEIGHT は「上限値」かつ既定値として残す（互換性のため）。
-// 実際のエクスポートキャンバスサイズはソース動画に応じて canvasStore で動的に決定される。
+// プレビュー描画は軽量に保つため 1280×720 を上限とする。
+// 書き出し時のみソース動画の解像度に応じて 1920×1080 まで動的に拡大する。
 export const MAX_CANVAS_WIDTH = 1920;
 export const MAX_CANVAS_HEIGHT = 1080;
-export const DEFAULT_CANVAS_WIDTH = MAX_CANVAS_WIDTH;
-export const DEFAULT_CANVAS_HEIGHT = MAX_CANVAS_HEIGHT;
-export const CANVAS_WIDTH = MAX_CANVAS_WIDTH;
-export const CANVAS_HEIGHT = MAX_CANVAS_HEIGHT;
+export const MAX_PREVIEW_CANVAS_WIDTH = 1280;
+export const MAX_PREVIEW_CANVAS_HEIGHT = 720;
+export const DEFAULT_CANVAS_WIDTH = MAX_PREVIEW_CANVAS_WIDTH;
+export const DEFAULT_CANVAS_HEIGHT = MAX_PREVIEW_CANVAS_HEIGHT;
+export const CANVAS_WIDTH = MAX_PREVIEW_CANVAS_WIDTH;
+export const CANVAS_HEIGHT = MAX_PREVIEW_CANVAS_HEIGHT;
 export const FPS = 30;
 
 // フェード設定

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -6,8 +6,14 @@
 import type { VoiceOption } from '../types';
 
 // キャンバス設定
-export const CANVAS_WIDTH = 1280;
-export const CANVAS_HEIGHT = 720;
+// CANVAS_WIDTH / CANVAS_HEIGHT は「上限値」かつ既定値として残す（互換性のため）。
+// 実際のエクスポートキャンバスサイズはソース動画に応じて canvasStore で動的に決定される。
+export const MAX_CANVAS_WIDTH = 1920;
+export const MAX_CANVAS_HEIGHT = 1080;
+export const DEFAULT_CANVAS_WIDTH = MAX_CANVAS_WIDTH;
+export const DEFAULT_CANVAS_HEIGHT = MAX_CANVAS_HEIGHT;
+export const CANVAS_WIDTH = MAX_CANVAS_WIDTH;
+export const CANVAS_HEIGHT = MAX_CANVAS_HEIGHT;
 export const FPS = 30;
 
 // フェード設定
@@ -62,4 +68,24 @@ export const VOICE_OPTIONS: VoiceOption[] = [
 ];
 
 // エクスポート設定
-export const EXPORT_VIDEO_BITRATE = 5000000; // 5Mbps
+// 1080p で 12 Mbps を目安に、実際のキャンバス解像度に比例した
+// ビットレートを計算する（最低 6 Mbps、上限 12 Mbps）。
+export const EXPORT_VIDEO_BITRATE = 12_000_000; // 12 Mbps (1920x1080 時の上限)
+export const EXPORT_VIDEO_BITRATE_MIN = 6_000_000; // 6 Mbps (低解像度時の下限)
+
+/**
+ * 与えられた解像度に応じてエクスポート用のビデオビットレートを算出する。
+ *
+ * 1920×1080 を基準に、画素数の比に応じて線形にスケーリングする。
+ * 圧縮アーティファクトを抑えるため、最低でも 6 Mbps は確保する。
+ */
+export function computeExportVideoBitrate(width: number, height: number): number {
+  if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+    return EXPORT_VIDEO_BITRATE;
+  }
+  const targetPixels = MAX_CANVAS_WIDTH * MAX_CANVAS_HEIGHT;
+  const actualPixels = width * height;
+  const ratio = Math.min(1, actualPixels / targetPixels);
+  const bitrate = Math.round(EXPORT_VIDEO_BITRATE * ratio);
+  return Math.max(EXPORT_VIDEO_BITRATE_MIN, bitrate);
+}

--- a/src/flavors/apple-safari/preview/usePreviewEngine.ts
+++ b/src/flavors/apple-safari/preview/usePreviewEngine.ts
@@ -1,8 +1,6 @@
 import { useCallback, type MutableRefObject } from 'react';
 
 import {
-  CANVAS_HEIGHT,
-  CANVAS_WIDTH,
   FPS,
 } from '../../../constants';
 import type {
@@ -267,6 +265,9 @@ export function usePreviewEngine({
         const duration = videoEl.duration;
         if (!isNaN(duration) && duration !== Infinity) {
           setVideoDuration(id, duration);
+          if (videoEl.videoWidth > 0 && videoEl.videoHeight > 0) {
+            useMediaStore.getState().setMediaSourceDimensions(id, videoEl.videoWidth, videoEl.videoHeight);
+          }
           logInfo('MEDIA', `ビデオロード完了: ${id.substring(0, 8)}...`, {
             duration: Math.round(duration * 10) / 10,
             readyState: videoEl.readyState,
@@ -643,7 +644,7 @@ export function usePreviewEngine({
           }
           ctx.globalAlpha = 1.0;
           ctx.fillStyle = '#000000';
-          ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+          ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
           didUpdateCanvas = true;
         }
 
@@ -833,10 +834,10 @@ export function usePreviewEngine({
                 const userX = conf.positionX || 0;
                 const userY = conf.positionY || 0;
 
-                const baseScale = Math.min(CANVAS_WIDTH / elemW, CANVAS_HEIGHT / elemH);
+                const baseScale = Math.min(ctx.canvas.width / elemW, ctx.canvas.height / elemH);
 
                 ctx.save();
-                ctx.translate(CANVAS_WIDTH / 2 + userX, CANVAS_HEIGHT / 2 + userY);
+                ctx.translate(ctx.canvas.width / 2 + userX, ctx.canvas.height / 2 + userY);
                 ctx.scale(baseScale * scaleFactor, baseScale * scaleFactor);
 
                 let alpha = 1.0;
@@ -1032,9 +1033,9 @@ export function usePreviewEngine({
             if (effectivePosition === 'top') {
               y = padding + fontSize / 2;
             } else if (effectivePosition === 'center') {
-              y = CANVAS_HEIGHT / 2;
+              y = ctx.canvas.height / 2;
             } else {
-              y = CANVAS_HEIGHT - padding - fontSize / 2;
+              y = ctx.canvas.height - padding - fontSize / 2;
             }
 
             const captionDuration = activeCaption.endTime - activeCaption.startTime;
@@ -1074,7 +1075,7 @@ export function usePreviewEngine({
             ctx.textBaseline = 'middle';
 
             const blurStrength = Math.max(0, currentCaptionSettings.blur);
-            const centerX = CANVAS_WIDTH / 2;
+            const centerX = ctx.canvas.width / 2;
             const drawCaptionGlyph = (
               x: number,
               yPos: number,

--- a/src/flavors/standard/preview/usePreviewEngine.ts
+++ b/src/flavors/standard/preview/usePreviewEngine.ts
@@ -1,8 +1,6 @@
 import { useCallback, useRef, type MutableRefObject } from 'react';
 
 import {
-  CANVAS_HEIGHT,
-  CANVAS_WIDTH,
   FPS,
 } from '../../../constants';
 import type {
@@ -795,6 +793,9 @@ export function usePreviewEngine({
         const duration = videoEl.duration;
         if (!isNaN(duration) && duration !== Infinity) {
           setVideoDuration(id, duration);
+          if (videoEl.videoWidth > 0 && videoEl.videoHeight > 0) {
+            useMediaStore.getState().setMediaSourceDimensions(id, videoEl.videoWidth, videoEl.videoHeight);
+          }
           logInfo('MEDIA', `ビデオロード完了: ${id.substring(0, 8)}...`, {
             duration: Math.round(duration * 10) / 10,
             readyState: videoEl.readyState,
@@ -1132,10 +1133,10 @@ export function usePreviewEngine({
         if (!_isExporting && hasReadyPreviewCache()) {
           const previewCacheVideo = previewCacheVideoRefValue.current;
           if (previewCacheVideo?.readyState && previewCacheVideo.readyState >= MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME) {
-            ctx.clearRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+            ctx.clearRect(0, 0, ctx.canvas.width, ctx.canvas.height);
             ctx.fillStyle = '#000000';
-            ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
-            ctx.drawImage(previewCacheVideo, 0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+            ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
+            ctx.drawImage(previewCacheVideo, 0, 0, ctx.canvas.width, ctx.canvas.height);
             return true;
           }
         }
@@ -1316,7 +1317,7 @@ export function usePreviewEngine({
               ) {
                 activeEl.pause();
                 ctx.globalAlpha = 1.0;
-                ctx.drawImage(activeEl, 0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+                ctx.drawImage(activeEl, 0, 0, ctx.canvas.width, ctx.canvas.height);
                 didUpdateCanvas = true;
                 holdFrame = true;
                 shouldSkipAndroidPreviewActiveDraw = true;
@@ -1537,7 +1538,7 @@ export function usePreviewEngine({
             previewTimelineDiagnosticsRef.current.lastShouldSuppressEndClear = false;
             ctx.globalAlpha = 1.0;
             ctx.fillStyle = '#000000';
-            ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+            ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
             didUpdateCanvas = true;
           }
         }
@@ -1905,10 +1906,10 @@ export function usePreviewEngine({
                 const userX = conf.positionX || 0;
                 const userY = conf.positionY || 0;
 
-                const baseScale = Math.min(CANVAS_WIDTH / elemW, CANVAS_HEIGHT / elemH);
+                const baseScale = Math.min(ctx.canvas.width / elemW, ctx.canvas.height / elemH);
 
                 ctx.save();
-                ctx.translate(CANVAS_WIDTH / 2 + userX, CANVAS_HEIGHT / 2 + userY);
+                ctx.translate(ctx.canvas.width / 2 + userX, ctx.canvas.height / 2 + userY);
                 ctx.scale(baseScale * scaleFactor, baseScale * scaleFactor);
 
                 let alpha = 1.0;
@@ -2143,9 +2144,9 @@ export function usePreviewEngine({
             if (effectivePosition === 'top') {
               y = padding + fontSize / 2;
             } else if (effectivePosition === 'center') {
-              y = CANVAS_HEIGHT / 2;
+              y = ctx.canvas.height / 2;
             } else {
-              y = CANVAS_HEIGHT - padding - fontSize / 2;
+              y = ctx.canvas.height - padding - fontSize / 2;
             }
 
             const captionDuration = activeCaption.endTime - activeCaption.startTime;
@@ -2185,7 +2186,7 @@ export function usePreviewEngine({
             ctx.textBaseline = 'middle';
 
             const blurStrength = Math.max(0, currentCaptionSettings.blur);
-            const centerX = CANVAS_WIDTH / 2;
+            const centerX = ctx.canvas.width / 2;
             const drawCaptionGlyph = (
               x: number,
               yPos: number,

--- a/src/hooks/useExport.ts
+++ b/src/hooks/useExport.ts
@@ -5,6 +5,7 @@
  */
 import { useState, useRef, useCallback } from 'react';
 import { FPS, computeExportVideoBitrate } from '../constants';
+import { useCanvasStore } from '../stores/canvasStore';
 import * as Mp4Muxer from 'mp4-muxer';
 import type { AudioTrack, NarrationClip } from '../types';
 import { useLogStore } from '../stores/logStore';
@@ -1217,15 +1218,10 @@ export function createUseExport(config: UseExportRuntimeConfig) {
         return;
       }
 
-      const exportVideoBitrate = computeExportVideoBitrate(
-        canvasRef.current.width,
-        canvasRef.current.height,
-      );
       logInfo('エクスポートを開始', {
-        width: canvasRef.current.width,
-        height: canvasRef.current.height,
+        previewWidth: canvasRef.current.width,
+        previewHeight: canvasRef.current.height,
         fps: FPS,
-        bitrate: exportVideoBitrate,
       });
       exportPhaseRef.current = 'preparing';
       logInfo('[EXPORT-FSM] transition', {
@@ -1460,6 +1456,29 @@ export function createUseExport(config: UseExportRuntimeConfig) {
       };
 
       try {
+        // キャンバスをエクスポート用の高解像度モードへ切り替える。
+        // プレビュー時は軽量サイズ（〜720p）で描画し、エクスポート時のみ最大 1080p で書き出す。
+        // React 再レンダリング前に captureStream が呼ばれる可能性があるため、
+        // canvas 要素の width/height は ref 経由で即座に書き換える。
+        useCanvasStore.getState().beginExportMode();
+        const { exportWidth, exportHeight } = useCanvasStore.getState();
+        if (canvasRef.current.width !== exportWidth) {
+          canvasRef.current.width = exportWidth;
+        }
+        if (canvasRef.current.height !== exportHeight) {
+          canvasRef.current.height = exportHeight;
+        }
+
+        const exportVideoBitrate = computeExportVideoBitrate(
+          canvasRef.current.width,
+          canvasRef.current.height,
+        );
+        logInfo('エクスポート用キャンバスサイズへ切替', {
+          width: canvasRef.current.width,
+          height: canvasRef.current.height,
+          bitrate: exportVideoBitrate,
+        });
+
         const strategyOrder = config.resolveExportStrategyOrder({
           isIosSafari,
           supportedMediaRecorderProfile,
@@ -2693,6 +2712,17 @@ export function createUseExport(config: UseExportRuntimeConfig) {
         exportPhaseRef.current = 'idle';
         silentAbortRef.current = false;
         setIsProcessing(false);
+        // キャンバスをプレビューサイズへ戻す（プレビュー描画を軽量に保つ）。
+        useCanvasStore.getState().endExportMode();
+        const { previewWidth, previewHeight } = useCanvasStore.getState();
+        if (canvasRef.current) {
+          if (canvasRef.current.width !== previewWidth) {
+            canvasRef.current.width = previewWidth;
+          }
+          if (canvasRef.current.height !== previewHeight) {
+            canvasRef.current.height = previewHeight;
+          }
+        }
       }
     },
     [completeExport, stopExport, updatePreparationStep]

--- a/src/hooks/useExport.ts
+++ b/src/hooks/useExport.ts
@@ -4,7 +4,7 @@
  * @description WebCodecs APIとmp4-muxerを使用して、編集内容をMP4ファイルとして書き出すためのカスタムフック。
  */
 import { useState, useRef, useCallback } from 'react';
-import { FPS, EXPORT_VIDEO_BITRATE } from '../constants';
+import { FPS, computeExportVideoBitrate } from '../constants';
 import * as Mp4Muxer from 'mp4-muxer';
 import type { AudioTrack, NarrationClip } from '../types';
 import { useLogStore } from '../stores/logStore';
@@ -1217,11 +1217,15 @@ export function createUseExport(config: UseExportRuntimeConfig) {
         return;
       }
 
+      const exportVideoBitrate = computeExportVideoBitrate(
+        canvasRef.current.width,
+        canvasRef.current.height,
+      );
       logInfo('エクスポートを開始', {
         width: canvasRef.current.width,
         height: canvasRef.current.height,
         fps: FPS,
-        bitrate: EXPORT_VIDEO_BITRATE
+        bitrate: exportVideoBitrate,
       });
       exportPhaseRef.current = 'preparing';
       logInfo('[EXPORT-FSM] transition', {
@@ -1511,7 +1515,7 @@ export function createUseExport(config: UseExportRuntimeConfig) {
               },
               exportConfig: {
                 fps: FPS,
-                videoBitrate: EXPORT_VIDEO_BITRATE,
+                videoBitrate: exportVideoBitrate,
               },
               supportedMediaRecorderProfile,
               diagnostics: {
@@ -1572,7 +1576,7 @@ export function createUseExport(config: UseExportRuntimeConfig) {
           codec: 'avc1.4d002a', // Main Profile, Level 4.2 (widely supported)
           width,
           height,
-          bitrate: EXPORT_VIDEO_BITRATE,
+          bitrate: exportVideoBitrate,
           framerate: FPS,
         });
 
@@ -2272,7 +2276,7 @@ export function createUseExport(config: UseExportRuntimeConfig) {
           removeEventListener: () => { },
           dispatchEvent: () => true,
           audioBitsPerSecond: 128000,
-          videoBitsPerSecond: EXPORT_VIDEO_BITRATE
+          videoBitsPerSecond: exportVideoBitrate
         } as unknown as MediaRecorder;
 
         // 音声プリレンダリング完了を通知 — エクスポート用の再生ループを開始させる

--- a/src/hooks/useMediaItems.ts
+++ b/src/hooks/useMediaItems.ts
@@ -5,6 +5,7 @@
  */
 import { useState, useCallback, useRef } from 'react';
 import type { MediaItem } from '../types';
+import { MAX_CANVAS_WIDTH, MAX_CANVAS_HEIGHT } from '../constants';
 
 /**
  * useMediaItems - メディアアイテムの状態管理と操作ロジックを提供するフック
@@ -119,6 +120,7 @@ export function useMediaItems(): UseMediaItemsReturn {
       if (element.tagName === 'VIDEO') {
         const videoEl = element as HTMLVideoElement;
         const duration = videoEl.duration;
+        const hasValidDimensions = videoEl.videoWidth > 0 && videoEl.videoHeight > 0;
         if (!isNaN(duration) && duration !== Infinity) {
           setMediaItems((prev) =>
             prev.map((v) => {
@@ -133,6 +135,8 @@ export function useMediaItems(): UseMediaItemsReturn {
                   trimStart: newTrimStart,
                   trimEnd: newTrimEnd,
                   duration: newDuration > 0 ? newDuration : duration,
+                  sourceWidth: hasValidDimensions ? videoEl.videoWidth : v.sourceWidth,
+                  sourceHeight: hasValidDimensions ? videoEl.videoHeight : v.sourceHeight,
                 };
               }
               return v;
@@ -201,7 +205,8 @@ export function useMediaItems(): UseMediaItemsReturn {
   const updateMediaPosition = useCallback((id: string, axis: 'x' | 'y', value: string) => {
     let val = parseFloat(value);
     if (isNaN(val)) val = 0;
-    val = Math.min(Math.max(val, -1280), 1280);
+    const limit = axis === 'x' ? MAX_CANVAS_WIDTH : MAX_CANVAS_HEIGHT;
+    val = Math.min(Math.max(val, -limit), limit);
     setMediaItems((prev) =>
       prev.map((v) => {
         if (v.id === id) {

--- a/src/hooks/usePlayback.ts
+++ b/src/hooks/usePlayback.ts
@@ -5,7 +5,6 @@
  */
 import { useState, useRef, useCallback } from 'react';
 import type { MediaItem, AudioTrack } from '../types';
-import { CANVAS_WIDTH, CANVAS_HEIGHT } from '../constants';
 
 /**
  * usePlayback - 再生制御ロジックを提供するフック
@@ -102,7 +101,7 @@ export function usePlayback(): UsePlaybackReturn {
 
         ctx.globalAlpha = 1.0;
         ctx.fillStyle = '#000000';
-        ctx.fillRect(0, 0, CANVAS_WIDTH, CANVAS_HEIGHT);
+        ctx.fillRect(0, 0, ctx.canvas.width, ctx.canvas.height);
 
         // Preload next video
         if (isActivePlaying && activeIndex !== -1 && activeIndex + 1 < currentItems.length) {
@@ -163,10 +162,10 @@ export function usePlayback(): UsePlaybackReturn {
                 const userX = conf.positionX || 0;
                 const userY = conf.positionY || 0;
 
-                const baseScale = Math.min(CANVAS_WIDTH / elemW, CANVAS_HEIGHT / elemH);
+                const baseScale = Math.min(ctx.canvas.width / elemW, ctx.canvas.height / elemH);
 
                 ctx.save();
-                ctx.translate(CANVAS_WIDTH / 2 + userX, CANVAS_HEIGHT / 2 + userY);
+                ctx.translate(ctx.canvas.width / 2 + userX, ctx.canvas.height / 2 + userY);
                 ctx.scale(baseScale * scaleFactor, baseScale * scaleFactor);
 
                 let alpha = 1.0;

--- a/src/stores/canvasStore.ts
+++ b/src/stores/canvasStore.ts
@@ -1,7 +1,11 @@
 /**
  * @file canvasStore.ts
  * @author Turtle Village
- * @description エクスポート対象のキャンバスサイズ（元動画の解像度に動的対応、ただし 1920×1080 上限・横向き固定）を管理するストア。
+ * @description プレビュー / エクスポートのキャンバスサイズを管理するストア。
+ *
+ * プレビューは描画負荷を抑えるため上限 1280×720 とする。
+ * 書き出し時のみ、ソース動画の解像度に応じて 1920×1080 まで動的に拡大する。
+ * 横向き固定とし、縦長ソースは既定サイズへフォールバックする。
  */
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
@@ -10,46 +14,75 @@ import {
   DEFAULT_CANVAS_HEIGHT,
   MAX_CANVAS_WIDTH,
   MAX_CANVAS_HEIGHT,
+  MAX_PREVIEW_CANVAS_WIDTH,
+  MAX_PREVIEW_CANVAS_HEIGHT,
 } from '../constants';
 
 interface CanvasState {
+  /** 現在キャンバス要素が取るサイズ（プレビュー時は preview*、エクスポート時は export*）。 */
   width: number;
   height: number;
-  setCanvasSize: (width: number, height: number) => void;
-  resetCanvasSize: () => void;
+  /** プレビュー専用のサイズ（軽量描画用、上限 1280×720）。 */
+  previewWidth: number;
+  previewHeight: number;
+  /** 書き出し時のキャンバスサイズ（最大 1920×1080）。 */
+  exportWidth: number;
+  exportHeight: number;
+  /** 現在エクスポートモードか。プレビューサイズへの自動戻しに使う。 */
+  isExportMode: boolean;
+  /** ソース動画の解像度を入力し、プレビュー/エクスポート両方のサイズを更新する。 */
   applyFromSource: (sourceWidth: number, sourceHeight: number) => void;
+  /** ストアを既定状態へ戻す。 */
+  resetCanvasSize: () => void;
+  /** 書き出し開始時に呼び出し、キャンバスを高解像度モードへ切り替える。 */
+  beginExportMode: () => void;
+  /** 書き出し終了時に呼び出し、プレビューサイズへ戻す。 */
+  endExportMode: () => void;
 }
 
 /**
- * ソース動画のサイズからエクスポート対象キャンバスサイズを算出する。
+ * ソースサイズと最大サイズから、横向き固定でキャンバスサイズを算出する。
  *
- * - 元動画のアスペクト比を可能な限り維持する。
- * - 横向き固定（縦長ソースの場合はデフォルトの 16:9 に戻す）。
- * - 1920×1080 を上限とする。
+ * - 縦長ソース（height > width）はフォールバックとして既定 16:9 サイズへ戻す。
+ * - 横長ソースはアスペクト比を保ったまま max{Width,Height} へ収まるよう縮小する。
+ * - H.264 の都合により幅・高さは偶数に丸める。
  */
 export function computeCanvasSizeFromSource(
   sourceWidth: number,
   sourceHeight: number,
+  maxWidth: number = MAX_CANVAS_WIDTH,
+  maxHeight: number = MAX_CANVAS_HEIGHT,
 ): { width: number; height: number } {
   if (!Number.isFinite(sourceWidth) || !Number.isFinite(sourceHeight)
     || sourceWidth <= 0 || sourceHeight <= 0) {
-    return { width: DEFAULT_CANVAS_WIDTH, height: DEFAULT_CANVAS_HEIGHT };
+    return fallbackLandscape(maxWidth, maxHeight);
   }
-  // 縦長ソースは横向き固定の方針に従いデフォルト 16:9 を返す
   if (sourceHeight > sourceWidth) {
-    return { width: DEFAULT_CANVAS_WIDTH, height: DEFAULT_CANVAS_HEIGHT };
+    return fallbackLandscape(maxWidth, maxHeight);
   }
-  if (sourceWidth <= MAX_CANVAS_WIDTH && sourceHeight <= MAX_CANVAS_HEIGHT) {
-    // H.264 はサイズを 2 の倍数にする必要があるため丸める
+  if (sourceWidth <= maxWidth && sourceHeight <= maxHeight) {
     return {
       width: roundToEven(sourceWidth),
       height: roundToEven(sourceHeight),
     };
   }
-  const scale = Math.min(MAX_CANVAS_WIDTH / sourceWidth, MAX_CANVAS_HEIGHT / sourceHeight);
+  const scale = Math.min(maxWidth / sourceWidth, maxHeight / sourceHeight);
   return {
     width: roundToEven(sourceWidth * scale),
     height: roundToEven(sourceHeight * scale),
+  };
+}
+
+function fallbackLandscape(maxWidth: number, maxHeight: number): { width: number; height: number } {
+  // 既定の 16:9 を最大枠に収める
+  const targetAspect = 16 / 9;
+  const widthByHeight = roundToEven(maxHeight * targetAspect);
+  if (widthByHeight <= maxWidth) {
+    return { width: widthByHeight, height: roundToEven(maxHeight) };
+  }
+  return {
+    width: roundToEven(maxWidth),
+    height: roundToEven(maxWidth / targetAspect),
   };
 }
 
@@ -59,20 +92,61 @@ function roundToEven(value: number): number {
 }
 
 export const useCanvasStore = create<CanvasState>()(
-  devtools((set) => ({
+  devtools((set, get) => ({
     width: DEFAULT_CANVAS_WIDTH,
     height: DEFAULT_CANVAS_HEIGHT,
-    setCanvasSize: (width, height) => set({
-      width: roundToEven(width),
-      height: roundToEven(height),
-    }),
+    previewWidth: DEFAULT_CANVAS_WIDTH,
+    previewHeight: DEFAULT_CANVAS_HEIGHT,
+    exportWidth: MAX_CANVAS_WIDTH,
+    exportHeight: MAX_CANVAS_HEIGHT,
+    isExportMode: false,
+    applyFromSource: (sourceWidth, sourceHeight) => {
+      const previewSize = computeCanvasSizeFromSource(
+        sourceWidth,
+        sourceHeight,
+        MAX_PREVIEW_CANVAS_WIDTH,
+        MAX_PREVIEW_CANVAS_HEIGHT,
+      );
+      const exportSize = computeCanvasSizeFromSource(
+        sourceWidth,
+        sourceHeight,
+        MAX_CANVAS_WIDTH,
+        MAX_CANVAS_HEIGHT,
+      );
+      const isExportMode = get().isExportMode;
+      set({
+        previewWidth: previewSize.width,
+        previewHeight: previewSize.height,
+        exportWidth: exportSize.width,
+        exportHeight: exportSize.height,
+        width: isExportMode ? exportSize.width : previewSize.width,
+        height: isExportMode ? exportSize.height : previewSize.height,
+      });
+    },
     resetCanvasSize: () => set({
       width: DEFAULT_CANVAS_WIDTH,
       height: DEFAULT_CANVAS_HEIGHT,
+      previewWidth: DEFAULT_CANVAS_WIDTH,
+      previewHeight: DEFAULT_CANVAS_HEIGHT,
+      exportWidth: MAX_CANVAS_WIDTH,
+      exportHeight: MAX_CANVAS_HEIGHT,
+      isExportMode: false,
     }),
-    applyFromSource: (sourceWidth, sourceHeight) => {
-      const size = computeCanvasSizeFromSource(sourceWidth, sourceHeight);
-      set(size);
+    beginExportMode: () => {
+      const { exportWidth, exportHeight } = get();
+      set({
+        isExportMode: true,
+        width: exportWidth,
+        height: exportHeight,
+      });
+    },
+    endExportMode: () => {
+      const { previewWidth, previewHeight } = get();
+      set({
+        isExportMode: false,
+        width: previewWidth,
+        height: previewHeight,
+      });
     },
   })),
 );

--- a/src/stores/canvasStore.ts
+++ b/src/stores/canvasStore.ts
@@ -1,0 +1,78 @@
+/**
+ * @file canvasStore.ts
+ * @author Turtle Village
+ * @description エクスポート対象のキャンバスサイズ（元動画の解像度に動的対応、ただし 1920×1080 上限・横向き固定）を管理するストア。
+ */
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+import {
+  DEFAULT_CANVAS_WIDTH,
+  DEFAULT_CANVAS_HEIGHT,
+  MAX_CANVAS_WIDTH,
+  MAX_CANVAS_HEIGHT,
+} from '../constants';
+
+interface CanvasState {
+  width: number;
+  height: number;
+  setCanvasSize: (width: number, height: number) => void;
+  resetCanvasSize: () => void;
+  applyFromSource: (sourceWidth: number, sourceHeight: number) => void;
+}
+
+/**
+ * ソース動画のサイズからエクスポート対象キャンバスサイズを算出する。
+ *
+ * - 元動画のアスペクト比を可能な限り維持する。
+ * - 横向き固定（縦長ソースの場合はデフォルトの 16:9 に戻す）。
+ * - 1920×1080 を上限とする。
+ */
+export function computeCanvasSizeFromSource(
+  sourceWidth: number,
+  sourceHeight: number,
+): { width: number; height: number } {
+  if (!Number.isFinite(sourceWidth) || !Number.isFinite(sourceHeight)
+    || sourceWidth <= 0 || sourceHeight <= 0) {
+    return { width: DEFAULT_CANVAS_WIDTH, height: DEFAULT_CANVAS_HEIGHT };
+  }
+  // 縦長ソースは横向き固定の方針に従いデフォルト 16:9 を返す
+  if (sourceHeight > sourceWidth) {
+    return { width: DEFAULT_CANVAS_WIDTH, height: DEFAULT_CANVAS_HEIGHT };
+  }
+  if (sourceWidth <= MAX_CANVAS_WIDTH && sourceHeight <= MAX_CANVAS_HEIGHT) {
+    // H.264 はサイズを 2 の倍数にする必要があるため丸める
+    return {
+      width: roundToEven(sourceWidth),
+      height: roundToEven(sourceHeight),
+    };
+  }
+  const scale = Math.min(MAX_CANVAS_WIDTH / sourceWidth, MAX_CANVAS_HEIGHT / sourceHeight);
+  return {
+    width: roundToEven(sourceWidth * scale),
+    height: roundToEven(sourceHeight * scale),
+  };
+}
+
+function roundToEven(value: number): number {
+  const rounded = Math.round(value);
+  return rounded % 2 === 0 ? rounded : rounded + 1;
+}
+
+export const useCanvasStore = create<CanvasState>()(
+  devtools((set) => ({
+    width: DEFAULT_CANVAS_WIDTH,
+    height: DEFAULT_CANVAS_HEIGHT,
+    setCanvasSize: (width, height) => set({
+      width: roundToEven(width),
+      height: roundToEven(height),
+    }),
+    resetCanvasSize: () => set({
+      width: DEFAULT_CANVAS_WIDTH,
+      height: DEFAULT_CANVAS_HEIGHT,
+    }),
+    applyFromSource: (sourceWidth, sourceHeight) => {
+      const size = computeCanvasSizeFromSource(sourceWidth, sourceHeight);
+      set(size);
+    },
+  })),
+);

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -21,3 +21,6 @@ export type { LogEntry, LogLevel, LogCategory, SystemInfo, MemoryStats } from '.
 
 // Project Store
 export { useProjectStore } from './projectStore';
+
+// Canvas Store
+export { useCanvasStore, computeCanvasSizeFromSource } from './canvasStore';

--- a/src/stores/mediaStore.ts
+++ b/src/stores/mediaStore.ts
@@ -35,6 +35,7 @@ interface MediaState {
 
   // Video specific
   setVideoDuration: (id: string, originalDuration: number) => void;
+  setMediaSourceDimensions: (id: string, sourceWidth: number, sourceHeight: number) => void;
   updateVideoTrim: (id: string, type: 'start' | 'end', value: number) => void;
 
   // Image specific
@@ -155,6 +156,24 @@ export const useMediaStore = create<MediaState>()(
             mediaItems: updated,
             totalDuration: calculateTotalDuration(updated),
           };
+        });
+      },
+
+      // Set source dimensions (called when video/image metadata loads)
+      setMediaSourceDimensions: (id, sourceWidth, sourceHeight) => {
+        if (!Number.isFinite(sourceWidth) || !Number.isFinite(sourceHeight)
+          || sourceWidth <= 0 || sourceHeight <= 0) {
+          return;
+        }
+        set((state) => {
+          const updated = state.mediaItems.map((item) => {
+            if (item.id !== id) return item;
+            if (item.sourceWidth === sourceWidth && item.sourceHeight === sourceHeight) {
+              return item;
+            }
+            return { ...item, sourceWidth, sourceHeight };
+          });
+          return { mediaItems: updated };
         });
       },
 

--- a/src/stores/projectStore.ts
+++ b/src/stores/projectStore.ts
@@ -318,6 +318,8 @@ async function serializeMediaItem(item: MediaItem): Promise<SerializedMediaItem>
     positionY: item.positionY,
     isTransformOpen: item.isTransformOpen,
     isLocked: item.isLocked,
+    sourceWidth: item.sourceWidth,
+    sourceHeight: item.sourceHeight,
   };
 }
 
@@ -344,6 +346,8 @@ function deserializeMediaItem(data: SerializedMediaItem): MediaItem {
     positionY: data.positionY,
     isTransformOpen: data.isTransformOpen,
     isLocked: data.isLocked,
+    sourceWidth: data.sourceWidth,
+    sourceHeight: data.sourceHeight,
   };
 }
 

--- a/src/test/canvasStore.test.ts
+++ b/src/test/canvasStore.test.ts
@@ -1,0 +1,124 @@
+/**
+ * @file canvasStore.test.ts
+ * @description Tests for dynamic canvas size resolution and computed export bitrate.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useCanvasStore, computeCanvasSizeFromSource } from '../stores/canvasStore';
+import {
+  computeExportVideoBitrate,
+  DEFAULT_CANVAS_WIDTH,
+  DEFAULT_CANVAS_HEIGHT,
+  MAX_CANVAS_WIDTH,
+  MAX_CANVAS_HEIGHT,
+  EXPORT_VIDEO_BITRATE,
+  EXPORT_VIDEO_BITRATE_MIN,
+} from '../constants';
+
+describe('computeCanvasSizeFromSource', () => {
+  it('returns default 1920x1080 when source dimensions are invalid', () => {
+    expect(computeCanvasSizeFromSource(0, 0)).toEqual({
+      width: DEFAULT_CANVAS_WIDTH,
+      height: DEFAULT_CANVAS_HEIGHT,
+    });
+    expect(computeCanvasSizeFromSource(NaN, 720)).toEqual({
+      width: DEFAULT_CANVAS_WIDTH,
+      height: DEFAULT_CANVAS_HEIGHT,
+    });
+  });
+
+  it('uses source dimensions when within cap (landscape)', () => {
+    expect(computeCanvasSizeFromSource(1280, 720)).toEqual({
+      width: 1280,
+      height: 720,
+    });
+    expect(computeCanvasSizeFromSource(854, 480)).toEqual({
+      width: 854,
+      height: 480,
+    });
+  });
+
+  it('caps source dimensions to 1920x1080 maintaining aspect ratio', () => {
+    expect(computeCanvasSizeFromSource(3840, 2160)).toEqual({
+      width: 1920,
+      height: 1080,
+    });
+    expect(computeCanvasSizeFromSource(1920, 1080)).toEqual({
+      width: 1920,
+      height: 1080,
+    });
+  });
+
+  it('falls back to default 1920x1080 for portrait sources (landscape-only policy)', () => {
+    expect(computeCanvasSizeFromSource(1080, 1920)).toEqual({
+      width: DEFAULT_CANVAS_WIDTH,
+      height: DEFAULT_CANVAS_HEIGHT,
+    });
+  });
+
+  it('preserves non-16:9 landscape aspect ratios', () => {
+    // 4:3 source 1024x768
+    expect(computeCanvasSizeFromSource(1024, 768)).toEqual({
+      width: 1024,
+      height: 768,
+    });
+  });
+
+  it('produces even width/height values (H.264 requirement)', () => {
+    const result = computeCanvasSizeFromSource(1919, 1079);
+    expect(result.width % 2).toBe(0);
+    expect(result.height % 2).toBe(0);
+  });
+});
+
+describe('useCanvasStore', () => {
+  beforeEach(() => {
+    useCanvasStore.getState().resetCanvasSize();
+  });
+
+  it('defaults to 1920x1080', () => {
+    const { width, height } = useCanvasStore.getState();
+    expect(width).toBe(MAX_CANVAS_WIDTH);
+    expect(height).toBe(MAX_CANVAS_HEIGHT);
+  });
+
+  it('applyFromSource updates dimensions according to source', () => {
+    useCanvasStore.getState().applyFromSource(1280, 720);
+    expect(useCanvasStore.getState().width).toBe(1280);
+    expect(useCanvasStore.getState().height).toBe(720);
+  });
+
+  it('applyFromSource caps oversized sources', () => {
+    useCanvasStore.getState().applyFromSource(3840, 2160);
+    expect(useCanvasStore.getState().width).toBe(1920);
+    expect(useCanvasStore.getState().height).toBe(1080);
+  });
+
+  it('resetCanvasSize returns to default', () => {
+    useCanvasStore.getState().applyFromSource(1280, 720);
+    useCanvasStore.getState().resetCanvasSize();
+    expect(useCanvasStore.getState().width).toBe(DEFAULT_CANVAS_WIDTH);
+    expect(useCanvasStore.getState().height).toBe(DEFAULT_CANVAS_HEIGHT);
+  });
+});
+
+describe('computeExportVideoBitrate', () => {
+  it('returns max 12 Mbps at 1920x1080', () => {
+    expect(computeExportVideoBitrate(1920, 1080)).toBe(EXPORT_VIDEO_BITRATE);
+  });
+
+  it('scales down proportionally for smaller resolutions', () => {
+    // 1280x720 has ~44% of the pixels of 1920x1080
+    // but minimum is 6 Mbps so the 1280x720 result is the floor
+    const bitrate = computeExportVideoBitrate(1280, 720);
+    expect(bitrate).toBeGreaterThanOrEqual(EXPORT_VIDEO_BITRATE_MIN);
+    expect(bitrate).toBeLessThanOrEqual(EXPORT_VIDEO_BITRATE);
+  });
+
+  it('does not go below the minimum (6 Mbps)', () => {
+    expect(computeExportVideoBitrate(640, 360)).toBe(EXPORT_VIDEO_BITRATE_MIN);
+  });
+
+  it('returns max bitrate for invalid dimensions', () => {
+    expect(computeExportVideoBitrate(0, 0)).toBe(EXPORT_VIDEO_BITRATE);
+  });
+});

--- a/src/test/canvasStore.test.ts
+++ b/src/test/canvasStore.test.ts
@@ -10,20 +10,20 @@ import {
   DEFAULT_CANVAS_HEIGHT,
   MAX_CANVAS_WIDTH,
   MAX_CANVAS_HEIGHT,
+  MAX_PREVIEW_CANVAS_WIDTH,
+  MAX_PREVIEW_CANVAS_HEIGHT,
   EXPORT_VIDEO_BITRATE,
   EXPORT_VIDEO_BITRATE_MIN,
 } from '../constants';
 
 describe('computeCanvasSizeFromSource', () => {
-  it('returns default 1920x1080 when source dimensions are invalid', () => {
-    expect(computeCanvasSizeFromSource(0, 0)).toEqual({
-      width: DEFAULT_CANVAS_WIDTH,
-      height: DEFAULT_CANVAS_HEIGHT,
-    });
-    expect(computeCanvasSizeFromSource(NaN, 720)).toEqual({
-      width: DEFAULT_CANVAS_WIDTH,
-      height: DEFAULT_CANVAS_HEIGHT,
-    });
+  it('returns landscape fallback when source dimensions are invalid', () => {
+    const fallback = computeCanvasSizeFromSource(0, 0);
+    expect(fallback.width).toBe(MAX_CANVAS_WIDTH);
+    expect(fallback.height).toBe(MAX_CANVAS_HEIGHT);
+    const nanFallback = computeCanvasSizeFromSource(NaN, 720);
+    expect(nanFallback.width).toBe(MAX_CANVAS_WIDTH);
+    expect(nanFallback.height).toBe(MAX_CANVAS_HEIGHT);
   });
 
   it('uses source dimensions when within cap (landscape)', () => {
@@ -37,7 +37,7 @@ describe('computeCanvasSizeFromSource', () => {
     });
   });
 
-  it('caps source dimensions to 1920x1080 maintaining aspect ratio', () => {
+  it('caps source dimensions to 1920x1080 maintaining aspect ratio (export cap)', () => {
     expect(computeCanvasSizeFromSource(3840, 2160)).toEqual({
       width: 1920,
       height: 1080,
@@ -48,19 +48,28 @@ describe('computeCanvasSizeFromSource', () => {
     });
   });
 
-  it('falls back to default 1920x1080 for portrait sources (landscape-only policy)', () => {
-    expect(computeCanvasSizeFromSource(1080, 1920)).toEqual({
-      width: DEFAULT_CANVAS_WIDTH,
-      height: DEFAULT_CANVAS_HEIGHT,
-    });
+  it('falls back to landscape default for portrait sources (landscape-only policy)', () => {
+    const result = computeCanvasSizeFromSource(1080, 1920);
+    expect(result.width).toBe(MAX_CANVAS_WIDTH);
+    expect(result.height).toBe(MAX_CANVAS_HEIGHT);
   });
 
   it('preserves non-16:9 landscape aspect ratios', () => {
-    // 4:3 source 1024x768
     expect(computeCanvasSizeFromSource(1024, 768)).toEqual({
       width: 1024,
       height: 768,
     });
+  });
+
+  it('caps preview at 1280x720 when given preview limits', () => {
+    const result = computeCanvasSizeFromSource(
+      1920,
+      1080,
+      MAX_PREVIEW_CANVAS_WIDTH,
+      MAX_PREVIEW_CANVAS_HEIGHT,
+    );
+    expect(result.width).toBe(1280);
+    expect(result.height).toBe(720);
   });
 
   it('produces even width/height values (H.264 requirement)', () => {
@@ -75,29 +84,56 @@ describe('useCanvasStore', () => {
     useCanvasStore.getState().resetCanvasSize();
   });
 
-  it('defaults to 1920x1080', () => {
-    const { width, height } = useCanvasStore.getState();
-    expect(width).toBe(MAX_CANVAS_WIDTH);
-    expect(height).toBe(MAX_CANVAS_HEIGHT);
+  it('defaults to preview size 1280x720 with separate export cap of 1920x1080', () => {
+    const state = useCanvasStore.getState();
+    expect(state.width).toBe(DEFAULT_CANVAS_WIDTH);
+    expect(state.height).toBe(DEFAULT_CANVAS_HEIGHT);
+    expect(state.previewWidth).toBe(MAX_PREVIEW_CANVAS_WIDTH);
+    expect(state.previewHeight).toBe(MAX_PREVIEW_CANVAS_HEIGHT);
+    expect(state.exportWidth).toBe(MAX_CANVAS_WIDTH);
+    expect(state.exportHeight).toBe(MAX_CANVAS_HEIGHT);
+    expect(state.isExportMode).toBe(false);
   });
 
-  it('applyFromSource updates dimensions according to source', () => {
-    useCanvasStore.getState().applyFromSource(1280, 720);
-    expect(useCanvasStore.getState().width).toBe(1280);
-    expect(useCanvasStore.getState().height).toBe(720);
+  it('applyFromSource updates both preview and export sizes independently', () => {
+    useCanvasStore.getState().applyFromSource(1920, 1080);
+    const state = useCanvasStore.getState();
+    expect(state.previewWidth).toBe(1280);
+    expect(state.previewHeight).toBe(720);
+    expect(state.exportWidth).toBe(1920);
+    expect(state.exportHeight).toBe(1080);
+    // current visible size is preview while not in export mode
+    expect(state.width).toBe(1280);
+    expect(state.height).toBe(720);
   });
 
-  it('applyFromSource caps oversized sources', () => {
-    useCanvasStore.getState().applyFromSource(3840, 2160);
-    expect(useCanvasStore.getState().width).toBe(1920);
-    expect(useCanvasStore.getState().height).toBe(1080);
+  it('beginExportMode switches current size to export dimensions', () => {
+    useCanvasStore.getState().applyFromSource(1920, 1080);
+    useCanvasStore.getState().beginExportMode();
+    const state = useCanvasStore.getState();
+    expect(state.isExportMode).toBe(true);
+    expect(state.width).toBe(1920);
+    expect(state.height).toBe(1080);
   });
 
-  it('resetCanvasSize returns to default', () => {
-    useCanvasStore.getState().applyFromSource(1280, 720);
+  it('endExportMode restores preview dimensions', () => {
+    useCanvasStore.getState().applyFromSource(1920, 1080);
+    useCanvasStore.getState().beginExportMode();
+    useCanvasStore.getState().endExportMode();
+    const state = useCanvasStore.getState();
+    expect(state.isExportMode).toBe(false);
+    expect(state.width).toBe(1280);
+    expect(state.height).toBe(720);
+  });
+
+  it('resetCanvasSize returns to defaults and exits export mode', () => {
+    useCanvasStore.getState().applyFromSource(1920, 1080);
+    useCanvasStore.getState().beginExportMode();
     useCanvasStore.getState().resetCanvasSize();
-    expect(useCanvasStore.getState().width).toBe(DEFAULT_CANVAS_WIDTH);
-    expect(useCanvasStore.getState().height).toBe(DEFAULT_CANVAS_HEIGHT);
+    const state = useCanvasStore.getState();
+    expect(state.isExportMode).toBe(false);
+    expect(state.width).toBe(DEFAULT_CANVAS_WIDTH);
+    expect(state.height).toBe(DEFAULT_CANVAS_HEIGHT);
   });
 });
 
@@ -106,9 +142,7 @@ describe('computeExportVideoBitrate', () => {
     expect(computeExportVideoBitrate(1920, 1080)).toBe(EXPORT_VIDEO_BITRATE);
   });
 
-  it('scales down proportionally for smaller resolutions', () => {
-    // 1280x720 has ~44% of the pixels of 1920x1080
-    // but minimum is 6 Mbps so the 1280x720 result is the floor
+  it('scales down proportionally for smaller resolutions but respects min', () => {
     const bitrate = computeExportVideoBitrate(1280, 720);
     expect(bitrate).toBeGreaterThanOrEqual(EXPORT_VIDEO_BITRATE_MIN);
     expect(bitrate).toBeLessThanOrEqual(EXPORT_VIDEO_BITRATE);

--- a/src/test/media.test.ts
+++ b/src/test/media.test.ts
@@ -194,9 +194,9 @@ describe('validateScale', () => {
 
 describe('validatePosition', () => {
   it('should clamp position to valid range', () => {
-    // default limit is 1280
-    expect(validatePosition(2000)).toBeLessThanOrEqual(1280);
-    expect(validatePosition(-2000)).toBeGreaterThanOrEqual(-1280);
+    // default limit is MAX_CANVAS_WIDTH (1920)
+    expect(validatePosition(3000)).toBeLessThanOrEqual(1920);
+    expect(validatePosition(-3000)).toBeGreaterThanOrEqual(-1920);
     expect(validatePosition(100)).toBe(100);
   });
 

--- a/src/test/standardPreviewEngine.test.tsx
+++ b/src/test/standardPreviewEngine.test.tsx
@@ -153,7 +153,9 @@ function createMockAudioElement() {
 
 function createMockCanvasContext() {
   return {
+    canvas: { width: 1920, height: 1080 },
     fillRect: vi.fn(),
+    clearRect: vi.fn(),
     drawImage: vi.fn(),
     save: vi.fn(),
     restore: vi.fn(),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -37,6 +37,9 @@ export interface MediaItem {
   positionY: number;
   isTransformOpen: boolean;
   isLocked: boolean;
+  // ソース動画の解像度（エクスポート用キャンバスサイズの動的決定に使用）
+  sourceWidth?: number;
+  sourceHeight?: number;
 }
 
 // オーディオトラック (BGM/ナレーション共通)

--- a/src/utils/indexedDB.ts
+++ b/src/utils/indexedDB.ts
@@ -59,6 +59,9 @@ export interface SerializedMediaItem {
   positionY: number;
   isTransformOpen: boolean;
   isLocked: boolean;
+  // ソース動画の解像度（エクスポートキャンバスサイズの動的決定に使用）
+  sourceWidth?: number;
+  sourceHeight?: number;
 }
 
 // 保存されるオーディオトラックのシリアライズ形式

--- a/src/utils/media.ts
+++ b/src/utils/media.ts
@@ -6,6 +6,7 @@
 
 import type { MediaItem } from '../types';
 import { useLogStore } from '../stores/logStore';
+import { MAX_CANVAS_WIDTH } from '../constants';
 
 /**
  * ID生成用カウンター（同一ミリ秒内での重複を防止）
@@ -165,7 +166,7 @@ export function validateScale(scale: number, min: number = 0.5, max: number = 3.
  * @param limit - 上限/下限
  * @returns 検証された位置値
  */
-export function validatePosition(position: number, limit: number = 1280): number {
+export function validatePosition(position: number, limit: number = MAX_CANVAS_WIDTH): number {
   if (isNaN(position)) return 0;
   return Math.max(-limit, Math.min(limit, position));
 }


### PR DESCRIPTION
- エクスポートキャンバスサイズを元動画の解像度に応じて動的に決定（1920×1080 上限・横向き固定）
- ビットレートを解像度に応じて算出（1080p で 12 Mbps、最低 6 Mbps）
- ソース動画の videoWidth/videoHeight を MediaItem に記録し、保存データにも含める
- プレビュー描画は ctx.canvas.width/height ベースに変更（CANVAS_WIDTH/HEIGHT 定数は上限値として保持）
- 位置スライダーの最大値もキャンバスサイズに連動