### PR TITLE
fix(preview): フェード描画を滑らかにし、キャプションの輪郭残りを解消

### DIFF
--- a/src/components/turtle-video/usePreviewEngine.ts
+++ b/src/components/turtle-video/usePreviewEngine.ts
@@ -3,6 +3,7 @@ import { useCallback, type MutableRefObject } from 'react';
 import {
   FPS,
 } from '../../constants';
+import { createCaptionGlyphCanvas, smoothstep } from '../../utils/canvas';
 import type {
   AudioTrack,
   Caption,
@@ -843,10 +844,10 @@ export function usePreviewEngine({
                 const fadeOutDur = conf.fadeOutDuration || 1.0;
 
                 if (conf.fadeIn && localTime < fadeInDur) {
-                  alpha = localTime / fadeInDur;
+                  alpha = smoothstep(localTime / fadeInDur);
                 } else if (conf.fadeOut && localTime > conf.duration - fadeOutDur) {
                   const remaining = conf.duration - localTime;
-                  alpha = remaining / fadeOutDur;
+                  alpha = smoothstep(remaining / fadeOutDur);
                 }
 
                 ctx.globalAlpha = Math.max(0, Math.min(1, alpha));
@@ -1057,45 +1058,40 @@ export function usePreviewEngine({
             let fadeOutAlpha = 1.0;
 
             if (useFadeIn && captionLocalTime < fadeInDur) {
-              fadeInAlpha = captionLocalTime / fadeInDur;
+              fadeInAlpha = smoothstep(captionLocalTime / fadeInDur);
             }
             if (useFadeOut && captionLocalTime > captionDuration - fadeOutDur) {
               const remaining = captionDuration - captionLocalTime;
-              fadeOutAlpha = remaining / fadeOutDur;
+              fadeOutAlpha = smoothstep(remaining / fadeOutDur);
             }
 
             const alpha = Math.max(0, Math.min(1, fadeInAlpha * fadeOutAlpha));
 
             ctx.save();
-            ctx.globalAlpha = alpha;
             ctx.font = `bold ${fontSize}px ${fontFamily}`;
             ctx.textAlign = 'center';
             ctx.textBaseline = 'middle';
 
             const blurStrength = Math.max(0, currentCaptionSettings.blur);
             const centerX = ctx.canvas.width / 2;
-            const drawCaptionGlyph = (
-              x: number,
-              yPos: number,
-              localAlpha: number,
-              options?: { stroke?: boolean; fill?: boolean },
-            ) => {
+
+            // フェード時の輪郭残りを防ぐため、stroke+fill を 1 枚のオフスクリーン Canvas に
+            // 100% の不透明度で合成してから、メインキャンバスへ globalAlpha 付きで転写する。
+            const glyphCanvas = createCaptionGlyphCanvas({
+              text: activeCaption.text,
+              font: `bold ${fontSize}px ${fontFamily}`,
+              fillColor: currentCaptionSettings.fontColor,
+              strokeColor: currentCaptionSettings.strokeColor,
+              strokeWidth: currentCaptionSettings.strokeWidth,
+            });
+            const glyphW = glyphCanvas.width;
+            const glyphH = glyphCanvas.height;
+            const drawGlyphAt = (cx: number, cy: number, localAlpha: number) => {
               const clamped = Math.max(0, Math.min(1, localAlpha));
               if (clamped <= 0) return;
               didUpdateCanvas = true;
               ctx.globalAlpha = alpha * clamped;
-              const drawStroke = options?.stroke ?? true;
-              const drawFill = options?.fill ?? true;
-              if (drawStroke) {
-                ctx.strokeStyle = currentCaptionSettings.strokeColor;
-                ctx.lineWidth = currentCaptionSettings.strokeWidth * 2;
-                ctx.lineJoin = 'round';
-                ctx.strokeText(activeCaption.text, x, yPos);
-              }
-              if (drawFill) {
-                ctx.fillStyle = currentCaptionSettings.fontColor;
-                ctx.fillText(activeCaption.text, x, yPos);
-              }
+              ctx.drawImage(glyphCanvas, cx - glyphW / 2, cy - glyphH / 2);
             };
 
             if (shouldUseCaptionBlurFallback(previewPlatformPolicy, blurStrength)) {
@@ -1116,27 +1112,24 @@ export function usePreviewEngine({
                   const angle = (Math.PI * 2 * i) / samplesPerRing;
                   const offsetX = Math.cos(angle) * radius;
                   const offsetY = Math.sin(angle) * radius;
-                  drawCaptionGlyph(centerX + offsetX, y + offsetY, sampleAlpha, { stroke: false, fill: true });
+                  drawGlyphAt(centerX + offsetX, y + offsetY, sampleAlpha);
                 }
               }
 
               ctx.globalCompositeOperation = prevComposite;
 
-              const coreFillAlpha = Math.max(0.35, 0.88 - blurNorm * 0.45);
-              const coreStrokeAlpha = Math.max(0, 0.9 - blurNorm * 1.4);
-
-              if (coreFillAlpha > 0.01) {
-                drawCaptionGlyph(centerX, y, coreFillAlpha, { stroke: false, fill: true });
-              }
-              if (coreStrokeAlpha > 0.01) {
-                drawCaptionGlyph(centerX, y, coreStrokeAlpha, { stroke: true, fill: false });
+              // 中央のクリスプなコア層。stroke と fill は glyphCanvas 内で既に合成済みのため、
+              // 単一のアルファ値で同期してフェードする (輪郭だけ残る現象を回避)。
+              const coreAlpha = Math.max(0.35, 0.9 - blurNorm * 0.45);
+              if (coreAlpha > 0.01) {
+                drawGlyphAt(centerX, y, coreAlpha);
               }
               ctx.restore();
               continue;
             }
 
             ctx.filter = blurStrength > 0 ? `blur(${blurStrength}px)` : 'none';
-            drawCaptionGlyph(centerX, y, 1);
+            drawGlyphAt(centerX, y, 1);
             ctx.restore();
           }
         }

--- a/src/flavors/apple-safari/preview/previewPlatform.ts
+++ b/src/flavors/apple-safari/preview/previewPlatform.ts
@@ -530,7 +530,9 @@ export function shouldBlackoutVideoFadeTail(
   }
 
   const remainingClipTime = Math.max(0, clipDuration - Math.max(0, options.clipLocalTime));
-  const blackoutAlphaThreshold = options.blackoutAlphaThreshold ?? 0.05;
+  // smoothstep フェード曲線下では tail のアルファ低下が早いため、ノイジーな最暗部を
+  // 黒で覆い隠す閾値を広めに取る (時間比 12% を末尾の黒置換ウィンドウとして使用)。
+  const blackoutAlphaThreshold = options.blackoutAlphaThreshold ?? 0.12;
   const minBlackoutWindowSec = options.minBlackoutWindowSec ?? (1 / 60);
   const maxBlackoutWindowSec = options.maxBlackoutWindowSec ?? 0.5;
   const alphaDerivedWindowSec = fadeOutDuration * blackoutAlphaThreshold;

--- a/src/flavors/apple-safari/preview/usePreviewEngine.ts
+++ b/src/flavors/apple-safari/preview/usePreviewEngine.ts
@@ -3,6 +3,7 @@ import { useCallback, type MutableRefObject } from 'react';
 import {
   FPS,
 } from '../../../constants';
+import { createCaptionGlyphCanvas, smoothstep } from '../../../utils/canvas';
 import type {
   AudioTrack,
   Caption,
@@ -845,10 +846,10 @@ export function usePreviewEngine({
                 const fadeOutDur = conf.fadeOutDuration || 1.0;
 
                 if (conf.fadeIn && localTime < fadeInDur) {
-                  alpha = localTime / fadeInDur;
+                  alpha = smoothstep(localTime / fadeInDur);
                 } else if (conf.fadeOut && localTime > conf.duration - fadeOutDur) {
                   const remaining = conf.duration - localTime;
-                  alpha = remaining / fadeOutDur;
+                  alpha = smoothstep(remaining / fadeOutDur);
                 }
 
                 ctx.globalAlpha = Math.max(0, Math.min(1, alpha));
@@ -1059,45 +1060,40 @@ export function usePreviewEngine({
             let fadeOutAlpha = 1.0;
 
             if (useFadeIn && captionLocalTime < fadeInDur) {
-              fadeInAlpha = captionLocalTime / fadeInDur;
+              fadeInAlpha = smoothstep(captionLocalTime / fadeInDur);
             }
             if (useFadeOut && captionLocalTime > captionDuration - fadeOutDur) {
               const remaining = captionDuration - captionLocalTime;
-              fadeOutAlpha = remaining / fadeOutDur;
+              fadeOutAlpha = smoothstep(remaining / fadeOutDur);
             }
 
             const alpha = Math.max(0, Math.min(1, fadeInAlpha * fadeOutAlpha));
 
             ctx.save();
-            ctx.globalAlpha = alpha;
             ctx.font = `bold ${fontSize}px ${fontFamily}`;
             ctx.textAlign = 'center';
             ctx.textBaseline = 'middle';
 
             const blurStrength = Math.max(0, currentCaptionSettings.blur);
             const centerX = ctx.canvas.width / 2;
-            const drawCaptionGlyph = (
-              x: number,
-              yPos: number,
-              localAlpha: number,
-              options?: { stroke?: boolean; fill?: boolean },
-            ) => {
+
+            // フェード時の輪郭残りを防ぐため、stroke+fill を 1 枚のオフスクリーン Canvas に
+            // 100% の不透明度で合成してから、メインキャンバスへ globalAlpha 付きで転写する。
+            const glyphCanvas = createCaptionGlyphCanvas({
+              text: activeCaption.text,
+              font: `bold ${fontSize}px ${fontFamily}`,
+              fillColor: currentCaptionSettings.fontColor,
+              strokeColor: currentCaptionSettings.strokeColor,
+              strokeWidth: currentCaptionSettings.strokeWidth,
+            });
+            const glyphW = glyphCanvas.width;
+            const glyphH = glyphCanvas.height;
+            const drawGlyphAt = (cx: number, cy: number, localAlpha: number) => {
               const clamped = Math.max(0, Math.min(1, localAlpha));
               if (clamped <= 0) return;
               didUpdateCanvas = true;
               ctx.globalAlpha = alpha * clamped;
-              const drawStroke = options?.stroke ?? true;
-              const drawFill = options?.fill ?? true;
-              if (drawStroke) {
-                ctx.strokeStyle = currentCaptionSettings.strokeColor;
-                ctx.lineWidth = currentCaptionSettings.strokeWidth * 2;
-                ctx.lineJoin = 'round';
-                ctx.strokeText(activeCaption.text, x, yPos);
-              }
-              if (drawFill) {
-                ctx.fillStyle = currentCaptionSettings.fontColor;
-                ctx.fillText(activeCaption.text, x, yPos);
-              }
+              ctx.drawImage(glyphCanvas, cx - glyphW / 2, cy - glyphH / 2);
             };
 
             if (shouldUseCaptionBlurFallback(previewPlatformPolicy, blurStrength)) {
@@ -1118,27 +1114,24 @@ export function usePreviewEngine({
                   const angle = (Math.PI * 2 * i) / samplesPerRing;
                   const offsetX = Math.cos(angle) * radius;
                   const offsetY = Math.sin(angle) * radius;
-                  drawCaptionGlyph(centerX + offsetX, y + offsetY, sampleAlpha, { stroke: false, fill: true });
+                  drawGlyphAt(centerX + offsetX, y + offsetY, sampleAlpha);
                 }
               }
 
               ctx.globalCompositeOperation = prevComposite;
 
-              const coreFillAlpha = Math.max(0.35, 0.88 - blurNorm * 0.45);
-              const coreStrokeAlpha = Math.max(0, 0.9 - blurNorm * 1.4);
-
-              if (coreFillAlpha > 0.01) {
-                drawCaptionGlyph(centerX, y, coreFillAlpha, { stroke: false, fill: true });
-              }
-              if (coreStrokeAlpha > 0.01) {
-                drawCaptionGlyph(centerX, y, coreStrokeAlpha, { stroke: true, fill: false });
+              // 中央のクリスプなコア層。stroke と fill は glyphCanvas 内で既に合成済みのため、
+              // 単一のアルファ値で同期してフェードする (輪郭だけ残る現象を回避)。
+              const coreAlpha = Math.max(0.35, 0.9 - blurNorm * 0.45);
+              if (coreAlpha > 0.01) {
+                drawGlyphAt(centerX, y, coreAlpha);
               }
               ctx.restore();
               continue;
             }
 
             ctx.filter = blurStrength > 0 ? `blur(${blurStrength}px)` : 'none';
-            drawCaptionGlyph(centerX, y, 1);
+            drawGlyphAt(centerX, y, 1);
             ctx.restore();
           }
         }

--- a/src/flavors/standard/preview/previewPlatform.ts
+++ b/src/flavors/standard/preview/previewPlatform.ts
@@ -530,7 +530,9 @@ export function shouldBlackoutVideoFadeTail(
   }
 
   const remainingClipTime = Math.max(0, clipDuration - Math.max(0, options.clipLocalTime));
-  const blackoutAlphaThreshold = options.blackoutAlphaThreshold ?? 0.05;
+  // smoothstep フェード曲線下では tail のアルファ低下が早いため、ノイジーな最暗部を
+  // 黒で覆い隠す閾値を広めに取る (時間比 12% を末尾の黒置換ウィンドウとして使用)。
+  const blackoutAlphaThreshold = options.blackoutAlphaThreshold ?? 0.12;
   const minBlackoutWindowSec = options.minBlackoutWindowSec ?? (1 / 60);
   const maxBlackoutWindowSec = options.maxBlackoutWindowSec ?? 0.5;
   const alphaDerivedWindowSec = fadeOutDuration * blackoutAlphaThreshold;

--- a/src/flavors/standard/preview/usePreviewEngine.ts
+++ b/src/flavors/standard/preview/usePreviewEngine.ts
@@ -3,6 +3,7 @@ import { useCallback, useRef, type MutableRefObject } from 'react';
 import {
   FPS,
 } from '../../../constants';
+import { createCaptionGlyphCanvas, smoothstep } from '../../../utils/canvas';
 import type {
   AudioTrack,
   Caption,
@@ -1917,10 +1918,10 @@ export function usePreviewEngine({
                 const fadeOutDur = conf.fadeOutDuration || 1.0;
 
                 if (conf.fadeIn && localTime < fadeInDur) {
-                  alpha = localTime / fadeInDur;
+                  alpha = smoothstep(localTime / fadeInDur);
                 } else if (conf.fadeOut && localTime > conf.duration - fadeOutDur) {
                   const remaining = conf.duration - localTime;
-                  alpha = remaining / fadeOutDur;
+                  alpha = smoothstep(remaining / fadeOutDur);
                 }
 
                 ctx.globalAlpha = Math.max(0, Math.min(1, alpha));
@@ -2170,45 +2171,40 @@ export function usePreviewEngine({
             let fadeOutAlpha = 1.0;
 
             if (useFadeIn && captionLocalTime < fadeInDur) {
-              fadeInAlpha = captionLocalTime / fadeInDur;
+              fadeInAlpha = smoothstep(captionLocalTime / fadeInDur);
             }
             if (useFadeOut && captionLocalTime > captionDuration - fadeOutDur) {
               const remaining = captionDuration - captionLocalTime;
-              fadeOutAlpha = remaining / fadeOutDur;
+              fadeOutAlpha = smoothstep(remaining / fadeOutDur);
             }
 
             const alpha = Math.max(0, Math.min(1, fadeInAlpha * fadeOutAlpha));
 
             ctx.save();
-            ctx.globalAlpha = alpha;
             ctx.font = `bold ${fontSize}px ${fontFamily}`;
             ctx.textAlign = 'center';
             ctx.textBaseline = 'middle';
 
             const blurStrength = Math.max(0, currentCaptionSettings.blur);
             const centerX = ctx.canvas.width / 2;
-            const drawCaptionGlyph = (
-              x: number,
-              yPos: number,
-              localAlpha: number,
-              options?: { stroke?: boolean; fill?: boolean },
-            ) => {
+
+            // フェード時の輪郭残りを防ぐため、stroke+fill を 1 枚のオフスクリーン Canvas に
+            // 100% の不透明度で合成してから、メインキャンバスへ globalAlpha 付きで転写する。
+            const glyphCanvas = createCaptionGlyphCanvas({
+              text: activeCaption.text,
+              font: `bold ${fontSize}px ${fontFamily}`,
+              fillColor: currentCaptionSettings.fontColor,
+              strokeColor: currentCaptionSettings.strokeColor,
+              strokeWidth: currentCaptionSettings.strokeWidth,
+            });
+            const glyphW = glyphCanvas.width;
+            const glyphH = glyphCanvas.height;
+            const drawGlyphAt = (cx: number, cy: number, localAlpha: number) => {
               const clamped = Math.max(0, Math.min(1, localAlpha));
               if (clamped <= 0) return;
               didUpdateCanvas = true;
               ctx.globalAlpha = alpha * clamped;
-              const drawStroke = options?.stroke ?? true;
-              const drawFill = options?.fill ?? true;
-              if (drawStroke) {
-                ctx.strokeStyle = currentCaptionSettings.strokeColor;
-                ctx.lineWidth = currentCaptionSettings.strokeWidth * 2;
-                ctx.lineJoin = 'round';
-                ctx.strokeText(activeCaption.text, x, yPos);
-              }
-              if (drawFill) {
-                ctx.fillStyle = currentCaptionSettings.fontColor;
-                ctx.fillText(activeCaption.text, x, yPos);
-              }
+              ctx.drawImage(glyphCanvas, cx - glyphW / 2, cy - glyphH / 2);
             };
 
             if (shouldUseCaptionBlurFallback(previewPlatformPolicy, blurStrength)) {
@@ -2229,27 +2225,24 @@ export function usePreviewEngine({
                   const angle = (Math.PI * 2 * i) / samplesPerRing;
                   const offsetX = Math.cos(angle) * radius;
                   const offsetY = Math.sin(angle) * radius;
-                  drawCaptionGlyph(centerX + offsetX, y + offsetY, sampleAlpha, { stroke: false, fill: true });
+                  drawGlyphAt(centerX + offsetX, y + offsetY, sampleAlpha);
                 }
               }
 
               ctx.globalCompositeOperation = prevComposite;
 
-              const coreFillAlpha = Math.max(0.35, 0.88 - blurNorm * 0.45);
-              const coreStrokeAlpha = Math.max(0, 0.9 - blurNorm * 1.4);
-
-              if (coreFillAlpha > 0.01) {
-                drawCaptionGlyph(centerX, y, coreFillAlpha, { stroke: false, fill: true });
-              }
-              if (coreStrokeAlpha > 0.01) {
-                drawCaptionGlyph(centerX, y, coreStrokeAlpha, { stroke: true, fill: false });
+              // 中央のクリスプなコア層。stroke と fill は glyphCanvas 内で既に合成済みのため、
+              // 単一のアルファ値で同期してフェードする (輪郭だけ残る現象を回避)。
+              const coreAlpha = Math.max(0.35, 0.9 - blurNorm * 0.45);
+              if (coreAlpha > 0.01) {
+                drawGlyphAt(centerX, y, coreAlpha);
               }
               ctx.restore();
               continue;
             }
 
             ctx.filter = blurStrength > 0 ? `blur(${blurStrength}px)` : 'none';
-            drawCaptionGlyph(centerX, y, 1);
+            drawGlyphAt(centerX, y, 1);
             ctx.restore();
           }
         }

--- a/src/test/previewPlatform.test.ts
+++ b/src/test/previewPlatform.test.ts
@@ -1263,11 +1263,11 @@ describe('preview platform helpers', () => {
     ).toBe(true);
   });
 
-  it('フェード終端の低アルファ帯（alpha < 閾値）では黒クリアを優先する', () => {
-    // remaining=0.04s, fadeOutDuration=1s → alpha=0.04 (< 0.05 閾値) → 黒クリア
+  it('フェード終端の低アルファ帯（時間比 < 12% 閾値）では黒クリアを優先する', () => {
+    // remaining=0.10s, fadeOutDuration=1s → 時間比=0.10 (< 0.12 閾値) → 黒クリア
     expect(
       shouldBlackoutVideoFadeTail({
-        clipLocalTime: 1.96,
+        clipLocalTime: 1.90,
         clipDuration: 2,
         fadeOut: true,
         fadeOutDuration: 1,
@@ -1276,10 +1276,10 @@ describe('preview platform helpers', () => {
   });
 
   it('フェード終端の blackout window 境界外ではフレーム保持を許可する', () => {
-    // remaining=0.06s, fadeOutDuration=1s → alpha=0.06 (> 0.05 閾値) → 保持許可
+    // remaining=0.13s, fadeOutDuration=1s → 時間比=0.13 (> 0.12 閾値) → 保持許可
     expect(
       shouldBlackoutVideoFadeTail({
-        clipLocalTime: 1.94,
+        clipLocalTime: 1.87,
         clipDuration: 2,
         fadeOut: true,
         fadeOutDuration: 1,
@@ -1299,7 +1299,7 @@ describe('preview platform helpers', () => {
   });
 
   it('長いフェードでも alphaDerivedWindow が maxBlackoutWindowSec で制限される', () => {
-    // fadeOutDuration=20s → alphaDerivedWindowSec = 20 * 0.05 = 1.0s
+    // fadeOutDuration=20s → alphaDerivedWindowSec = 20 * 0.12 = 2.4s
     // maxBlackoutWindowSec = 0.5s で制限 → blackoutWindowSec = 0.5s
     // remaining=0.51s > 0.5s → false
     expect(

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -54,7 +54,17 @@ export function calculateFitScale(
 }
 
 /**
- * フェードアルファ値を計算
+ * 0..1 を smoothstep (3t^2 - 2t^3) で滑らかにする。
+ * 線形フェードに比べ知覚的なザラつきが減り、一般的な動画編集ソフトの
+ * フェード曲線に近い印象になる。
+ */
+export function smoothstep(t: number): number {
+  const clamped = Math.max(0, Math.min(1, t));
+  return clamped * clamped * (3 - 2 * clamped);
+}
+
+/**
+ * フェードアルファ値を計算（smoothstep でイージング）
  * @param localTime - ローカル再生時間
  * @param duration - 総再生時間
  * @param fadeIn - フェードイン有効
@@ -72,9 +82,9 @@ export function calculateFadeAlpha(
   let alpha = 1.0;
 
   if (fadeIn && localTime < fadeDuration) {
-    alpha = localTime / fadeDuration;
+    alpha = smoothstep(localTime / fadeDuration);
   } else if (fadeOut && localTime > duration - fadeDuration) {
-    alpha = (duration - localTime) / fadeDuration;
+    alpha = smoothstep((duration - localTime) / fadeDuration);
   }
 
   return Math.max(0, Math.min(1, alpha));
@@ -141,6 +151,82 @@ export function safeSetVideoTime(
   if (Number.isFinite(time) && Number.isFinite(max)) {
     video.currentTime = Math.max(0, Math.min(max, time));
   }
+}
+
+export interface CaptionGlyphOptions {
+  text: string;
+  font: string;
+  fillColor: string;
+  strokeColor: string;
+  strokeWidth: number;
+}
+
+/**
+ * キャプション文字（stroke + fill）を 1 枚のオフスクリーン Canvas に描画して返す。
+ * 呼び出し側はこの Canvas を `drawImage` でメインキャンバスに転写するだけで済むため、
+ * フェード時に stroke と fill が二重にアルファ合成されて「輪郭だけ残る」現象を防げる。
+ *
+ * 文字幅は呼び出し前に `font` を設定した一時 Canvas で計測する。
+ * ストローク太さや句読点による descenders を含めるため左右上下に余白を確保する。
+ */
+export function createCaptionGlyphCanvas(options: CaptionGlyphOptions): HTMLCanvasElement {
+  const { text, font, fillColor, strokeColor, strokeWidth } = options;
+
+  const measureCanvas = document.createElement('canvas');
+  const measureCtx = measureCanvas.getContext('2d');
+  if (!measureCtx) {
+    measureCanvas.width = 1;
+    measureCanvas.height = 1;
+    return measureCanvas;
+  }
+  measureCtx.font = font;
+  measureCtx.textBaseline = 'middle';
+  const metrics = measureCtx.measureText(text);
+
+  // フォントサイズを font 文字列から推定（フォールバック）
+  const fontSizeMatch = /(\d+(?:\.\d+)?)px/.exec(font);
+  const inferredFontSize = fontSizeMatch ? parseFloat(fontSizeMatch[1]) : 48;
+
+  const ascent = Number.isFinite(metrics.actualBoundingBoxAscent)
+    ? metrics.actualBoundingBoxAscent
+    : inferredFontSize * 0.8;
+  const descent = Number.isFinite(metrics.actualBoundingBoxDescent)
+    ? metrics.actualBoundingBoxDescent
+    : inferredFontSize * 0.3;
+
+  // strokeWidth はキャプション設定値で、描画時には *2 した lineWidth を使う。
+  // ストロークは線の中心を境に内外に広がるため、片側で strokeWidth 分のはみ出しが起きる。
+  // 加えてアンチエイリアスの余白として数 px 確保する。
+  const paddingX = Math.ceil(strokeWidth * 2 + 8);
+  const paddingY = Math.ceil(strokeWidth * 2 + 8);
+  const width = Math.max(1, Math.ceil(metrics.width) + paddingX * 2);
+  const height = Math.max(1, Math.ceil(ascent + descent) + paddingY * 2);
+
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return canvas;
+
+  ctx.font = font;
+  ctx.textAlign = 'center';
+  ctx.textBaseline = 'middle';
+  ctx.lineJoin = 'round';
+
+  const centerX = width / 2;
+  const centerY = height / 2;
+
+  // stroke を先に描き、その上に fill を載せる。オフスクリーン内では globalAlpha=1.0 のため
+  // stroke と fill が二重合成される問題は起きず、外側ストロークと内側塗りが想定通り重なる。
+  if (strokeWidth > 0) {
+    ctx.strokeStyle = strokeColor;
+    ctx.lineWidth = strokeWidth * 2;
+    ctx.strokeText(text, centerX, centerY);
+  }
+  ctx.fillStyle = fillColor;
+  ctx.fillText(text, centerX, centerY);
+
+  return canvas;
 }
 
 /**

--- a/src/utils/previewPlatform.ts
+++ b/src/utils/previewPlatform.ts
@@ -541,7 +541,9 @@ export function shouldBlackoutVideoFadeTail(
   }
 
   const remainingClipTime = Math.max(0, clipDuration - Math.max(0, options.clipLocalTime));
-  const blackoutAlphaThreshold = options.blackoutAlphaThreshold ?? 0.05;
+  // smoothstep フェード曲線下では tail のアルファ低下が早いため、ノイジーな最暗部を
+  // 黒で覆い隠す閾値を広めに取る (時間比 12% を末尾の黒置換ウィンドウとして使用)。
+  const blackoutAlphaThreshold = options.blackoutAlphaThreshold ?? 0.12;
   const minBlackoutWindowSec = options.minBlackoutWindowSec ?? (1 / 60);
   const maxBlackoutWindowSec = options.maxBlackoutWindowSec ?? 0.5;
   const alphaDerivedWindowSec = fadeOutDuration * blackoutAlphaThreshold;


### PR DESCRIPTION
動画/画像/キャプションのフェードイン・アウトを線形補間から smoothstep
(3t² - 2t³) に変更し、プレビュー/エクスポート双方で知覚的に滑らかな
フェード曲線にする。曲線変更に伴いフェード末尾の暗部が短時間で抜ける
ため、shouldBlackoutVideoFadeTail の閾値を 5% → 12% に拡大して
ノイジーな最暗フレームの露出時間をさらに短縮する。

キャプションは drawCaptionGlyph が毎フレーム strokeText → fillText を
同一キャンバスへ重ね描きしており、globalAlpha < 1 のとき内側の塗りに
ストロークの寄与が二重合成されて「輪郭だけ残って見える」状態になって
いた。createCaptionGlyphCanvas で stroke+fill を 1 枚のオフスクリーン
Canvas に 100% 不透明で合成してから globalAlpha 付きで転写するよう
変更し、輪郭と中身が同じ速度で同期してフェードするようにした。
iOS Safari の blur fallback の core レイヤーも単一アルファに統一。

https://claude.ai/code/session_015CRHwiikGD9jDtrzLDCNud