### PR TITLE
fix(preview): フェードを線形に戻し、見えなくなった問題を修正

### DIFF
--- a/src/components/turtle-video/usePreviewEngine.ts
+++ b/src/components/turtle-video/usePreviewEngine.ts
@@ -3,7 +3,7 @@ import { useCallback, type MutableRefObject } from 'react';
 import {
   FPS,
 } from '../../constants';
-import { createCaptionGlyphCanvas, smoothstep } from '../../utils/canvas';
+import { createCaptionGlyphCanvas } from '../../utils/canvas';
 import type {
   AudioTrack,
   Caption,
@@ -844,10 +844,10 @@ export function usePreviewEngine({
                 const fadeOutDur = conf.fadeOutDuration || 1.0;
 
                 if (conf.fadeIn && localTime < fadeInDur) {
-                  alpha = smoothstep(localTime / fadeInDur);
+                  alpha = localTime / fadeInDur;
                 } else if (conf.fadeOut && localTime > conf.duration - fadeOutDur) {
                   const remaining = conf.duration - localTime;
-                  alpha = smoothstep(remaining / fadeOutDur);
+                  alpha = remaining / fadeOutDur;
                 }
 
                 ctx.globalAlpha = Math.max(0, Math.min(1, alpha));
@@ -1058,11 +1058,11 @@ export function usePreviewEngine({
             let fadeOutAlpha = 1.0;
 
             if (useFadeIn && captionLocalTime < fadeInDur) {
-              fadeInAlpha = smoothstep(captionLocalTime / fadeInDur);
+              fadeInAlpha = captionLocalTime / fadeInDur;
             }
             if (useFadeOut && captionLocalTime > captionDuration - fadeOutDur) {
               const remaining = captionDuration - captionLocalTime;
-              fadeOutAlpha = smoothstep(remaining / fadeOutDur);
+              fadeOutAlpha = remaining / fadeOutDur;
             }
 
             const alpha = Math.max(0, Math.min(1, fadeInAlpha * fadeOutAlpha));

--- a/src/flavors/apple-safari/preview/previewPlatform.ts
+++ b/src/flavors/apple-safari/preview/previewPlatform.ts
@@ -530,9 +530,7 @@ export function shouldBlackoutVideoFadeTail(
   }
 
   const remainingClipTime = Math.max(0, clipDuration - Math.max(0, options.clipLocalTime));
-  // smoothstep フェード曲線下では tail のアルファ低下が早いため、ノイジーな最暗部を
-  // 黒で覆い隠す閾値を広めに取る (時間比 12% を末尾の黒置換ウィンドウとして使用)。
-  const blackoutAlphaThreshold = options.blackoutAlphaThreshold ?? 0.12;
+  const blackoutAlphaThreshold = options.blackoutAlphaThreshold ?? 0.05;
   const minBlackoutWindowSec = options.minBlackoutWindowSec ?? (1 / 60);
   const maxBlackoutWindowSec = options.maxBlackoutWindowSec ?? 0.5;
   const alphaDerivedWindowSec = fadeOutDuration * blackoutAlphaThreshold;

--- a/src/flavors/apple-safari/preview/usePreviewEngine.ts
+++ b/src/flavors/apple-safari/preview/usePreviewEngine.ts
@@ -3,7 +3,7 @@ import { useCallback, type MutableRefObject } from 'react';
 import {
   FPS,
 } from '../../../constants';
-import { createCaptionGlyphCanvas, smoothstep } from '../../../utils/canvas';
+import { createCaptionGlyphCanvas } from '../../../utils/canvas';
 import type {
   AudioTrack,
   Caption,
@@ -846,10 +846,10 @@ export function usePreviewEngine({
                 const fadeOutDur = conf.fadeOutDuration || 1.0;
 
                 if (conf.fadeIn && localTime < fadeInDur) {
-                  alpha = smoothstep(localTime / fadeInDur);
+                  alpha = localTime / fadeInDur;
                 } else if (conf.fadeOut && localTime > conf.duration - fadeOutDur) {
                   const remaining = conf.duration - localTime;
-                  alpha = smoothstep(remaining / fadeOutDur);
+                  alpha = remaining / fadeOutDur;
                 }
 
                 ctx.globalAlpha = Math.max(0, Math.min(1, alpha));
@@ -1060,11 +1060,11 @@ export function usePreviewEngine({
             let fadeOutAlpha = 1.0;
 
             if (useFadeIn && captionLocalTime < fadeInDur) {
-              fadeInAlpha = smoothstep(captionLocalTime / fadeInDur);
+              fadeInAlpha = captionLocalTime / fadeInDur;
             }
             if (useFadeOut && captionLocalTime > captionDuration - fadeOutDur) {
               const remaining = captionDuration - captionLocalTime;
-              fadeOutAlpha = smoothstep(remaining / fadeOutDur);
+              fadeOutAlpha = remaining / fadeOutDur;
             }
 
             const alpha = Math.max(0, Math.min(1, fadeInAlpha * fadeOutAlpha));

--- a/src/flavors/standard/preview/previewPlatform.ts
+++ b/src/flavors/standard/preview/previewPlatform.ts
@@ -530,9 +530,7 @@ export function shouldBlackoutVideoFadeTail(
   }
 
   const remainingClipTime = Math.max(0, clipDuration - Math.max(0, options.clipLocalTime));
-  // smoothstep フェード曲線下では tail のアルファ低下が早いため、ノイジーな最暗部を
-  // 黒で覆い隠す閾値を広めに取る (時間比 12% を末尾の黒置換ウィンドウとして使用)。
-  const blackoutAlphaThreshold = options.blackoutAlphaThreshold ?? 0.12;
+  const blackoutAlphaThreshold = options.blackoutAlphaThreshold ?? 0.05;
   const minBlackoutWindowSec = options.minBlackoutWindowSec ?? (1 / 60);
   const maxBlackoutWindowSec = options.maxBlackoutWindowSec ?? 0.5;
   const alphaDerivedWindowSec = fadeOutDuration * blackoutAlphaThreshold;

--- a/src/flavors/standard/preview/usePreviewEngine.ts
+++ b/src/flavors/standard/preview/usePreviewEngine.ts
@@ -3,7 +3,7 @@ import { useCallback, useRef, type MutableRefObject } from 'react';
 import {
   FPS,
 } from '../../../constants';
-import { createCaptionGlyphCanvas, smoothstep } from '../../../utils/canvas';
+import { createCaptionGlyphCanvas } from '../../../utils/canvas';
 import type {
   AudioTrack,
   Caption,
@@ -1918,10 +1918,10 @@ export function usePreviewEngine({
                 const fadeOutDur = conf.fadeOutDuration || 1.0;
 
                 if (conf.fadeIn && localTime < fadeInDur) {
-                  alpha = smoothstep(localTime / fadeInDur);
+                  alpha = localTime / fadeInDur;
                 } else if (conf.fadeOut && localTime > conf.duration - fadeOutDur) {
                   const remaining = conf.duration - localTime;
-                  alpha = smoothstep(remaining / fadeOutDur);
+                  alpha = remaining / fadeOutDur;
                 }
 
                 ctx.globalAlpha = Math.max(0, Math.min(1, alpha));
@@ -2171,11 +2171,11 @@ export function usePreviewEngine({
             let fadeOutAlpha = 1.0;
 
             if (useFadeIn && captionLocalTime < fadeInDur) {
-              fadeInAlpha = smoothstep(captionLocalTime / fadeInDur);
+              fadeInAlpha = captionLocalTime / fadeInDur;
             }
             if (useFadeOut && captionLocalTime > captionDuration - fadeOutDur) {
               const remaining = captionDuration - captionLocalTime;
-              fadeOutAlpha = smoothstep(remaining / fadeOutDur);
+              fadeOutAlpha = remaining / fadeOutDur;
             }
 
             const alpha = Math.max(0, Math.min(1, fadeInAlpha * fadeOutAlpha));

--- a/src/test/previewPlatform.test.ts
+++ b/src/test/previewPlatform.test.ts
@@ -1263,11 +1263,11 @@ describe('preview platform helpers', () => {
     ).toBe(true);
   });
 
-  it('フェード終端の低アルファ帯（時間比 < 12% 閾値）では黒クリアを優先する', () => {
-    // remaining=0.10s, fadeOutDuration=1s → 時間比=0.10 (< 0.12 閾値) → 黒クリア
+  it('フェード終端の低アルファ帯（alpha < 閾値）では黒クリアを優先する', () => {
+    // remaining=0.04s, fadeOutDuration=1s → alpha=0.04 (< 0.05 閾値) → 黒クリア
     expect(
       shouldBlackoutVideoFadeTail({
-        clipLocalTime: 1.90,
+        clipLocalTime: 1.96,
         clipDuration: 2,
         fadeOut: true,
         fadeOutDuration: 1,
@@ -1276,10 +1276,10 @@ describe('preview platform helpers', () => {
   });
 
   it('フェード終端の blackout window 境界外ではフレーム保持を許可する', () => {
-    // remaining=0.13s, fadeOutDuration=1s → 時間比=0.13 (> 0.12 閾値) → 保持許可
+    // remaining=0.06s, fadeOutDuration=1s → alpha=0.06 (> 0.05 閾値) → 保持許可
     expect(
       shouldBlackoutVideoFadeTail({
-        clipLocalTime: 1.87,
+        clipLocalTime: 1.94,
         clipDuration: 2,
         fadeOut: true,
         fadeOutDuration: 1,
@@ -1299,7 +1299,7 @@ describe('preview platform helpers', () => {
   });
 
   it('長いフェードでも alphaDerivedWindow が maxBlackoutWindowSec で制限される', () => {
-    // fadeOutDuration=20s → alphaDerivedWindowSec = 20 * 0.12 = 2.4s
+    // fadeOutDuration=20s → alphaDerivedWindowSec = 20 * 0.05 = 1.0s
     // maxBlackoutWindowSec = 0.5s で制限 → blackoutWindowSec = 0.5s
     // remaining=0.51s > 0.5s → false
     expect(

--- a/src/utils/canvas.ts
+++ b/src/utils/canvas.ts
@@ -54,17 +54,13 @@ export function calculateFitScale(
 }
 
 /**
- * 0..1 を smoothstep (3t^2 - 2t^3) で滑らかにする。
- * 線形フェードに比べ知覚的なザラつきが減り、一般的な動画編集ソフトの
- * フェード曲線に近い印象になる。
- */
-export function smoothstep(t: number): number {
-  const clamped = Math.max(0, Math.min(1, t));
-  return clamped * clamped * (3 - 2 * clamped);
-}
-
-/**
- * フェードアルファ値を計算（smoothstep でイージング）
+ * フェードアルファ値を計算（線形補間）
+ *
+ * 一般的な動画編集ソフトと同様、フェード期間中の経過時間にアルファ値を比例させる。
+ * イージング曲線 (smoothstep など) は一見滑らかに見えても、開始/終了付近のアルファ変化が
+ * 知覚できないほど小さくなり「フェードが始まらない / 終わらない」印象を与えるため、
+ * プレビューでは線形が最も自然に映る。
+ *
  * @param localTime - ローカル再生時間
  * @param duration - 総再生時間
  * @param fadeIn - フェードイン有効
@@ -82,9 +78,9 @@ export function calculateFadeAlpha(
   let alpha = 1.0;
 
   if (fadeIn && localTime < fadeDuration) {
-    alpha = smoothstep(localTime / fadeDuration);
+    alpha = localTime / fadeDuration;
   } else if (fadeOut && localTime > duration - fadeDuration) {
-    alpha = smoothstep((duration - localTime) / fadeDuration);
+    alpha = (duration - localTime) / fadeDuration;
   }
 
   return Math.max(0, Math.min(1, alpha));

--- a/src/utils/previewPlatform.ts
+++ b/src/utils/previewPlatform.ts
@@ -541,9 +541,7 @@ export function shouldBlackoutVideoFadeTail(
   }
 
   const remainingClipTime = Math.max(0, clipDuration - Math.max(0, options.clipLocalTime));
-  // smoothstep フェード曲線下では tail のアルファ低下が早いため、ノイジーな最暗部を
-  // 黒で覆い隠す閾値を広めに取る (時間比 12% を末尾の黒置換ウィンドウとして使用)。
-  const blackoutAlphaThreshold = options.blackoutAlphaThreshold ?? 0.12;
+  const blackoutAlphaThreshold = options.blackoutAlphaThreshold ?? 0.05;
   const minBlackoutWindowSec = options.minBlackoutWindowSec ?? (1 / 60);
   const maxBlackoutWindowSec = options.maxBlackoutWindowSec ?? 0.5;
   const alphaDerivedWindowSec = fadeOutDuration * blackoutAlphaThreshold;


### PR DESCRIPTION
## Summary

PR #183 で導入した smoothstep フェード曲線が原因で「プレビューでフェードイン/アウトが全く表示されない」状態になっていたため、業界標準の線形補間に戻します。キャプションのオフスクリーン合成 (輪郭残り問題の修正) は維持します。

## 問題の分析

`smoothstep(t) = 3t² - 2t³` は数学的には滑らかな S 字曲線ですが、動画フェードに適用すると視聴体験を損ねる特性があります:

| t (時間進行) | smoothstep(t) | 線形 (t) |
|---:|---:|---:|
| 0.1 | 0.028 | 0.10 |
| 0.2 | 0.104 | 0.20 |
| 0.5 | 0.500 | 0.50 |
| 0.8 | 0.896 | 0.80 |
| 0.9 | 0.972 | 0.90 |

1 秒のフェードアウトの場合、最初の 200ms はアルファが 1.00→0.90 とほぼ変化せず、ユーザーには「フェードがいつまでも始まらない」ように見えます。さらに 12% に拡大した blackout 閾値が末尾を黒で覆ってしまうため、視覚上は「動画が普通に再生されて突然黒になる = フェード無し」と認識されてしまいました。

業界標準の線形フェードはフェード期間中ずっと均等にアルファが変化するため、視聴者から見て「期間と見える変化が一致」する自然なフェードになります。

## 変更内容

- 動画/画像/キャプションのフェード math を smoothstep から線形に戻す (3 つの `usePreviewEngine.ts` + `utils/canvas.ts`)
- `shouldBlackoutVideoFadeTail` の閾値を 12% → 5% に戻す (3 ファイル)
- 関連テストの期待値を 5% 閾値に戻す
- 未使用となった `smoothstep` export を削除

## 維持する修正

PR #183 で行ったキャプションのオフスクリーン合成 (`createCaptionGlyphCanvas`) は、`strokeText` と `fillText` を別々に `globalAlpha` 経由でメインキャンバスに重ねていたことによる「輪郭だけ残って見える」現象を解消する正当なバグ修正です。線形フェードでも引き続き有効に機能するため維持します。

## Test plan

- [x] `npx tsc --noEmit` 通過
- [x] `npx vitest run` 全 403 テスト パス
- [ ] プレビュー画面で動画フェードイン/フェードアウトが滑らかに表示されることを確認
- [ ] プレビュー画面で画像フェードイン/フェードアウトが滑らかに表示されることを確認
- [ ] キャプションのフェードで「輪郭だけ残る」現象が起きないことを確認
- [ ] エクスポートした動画でも同様にフェードが正しく表示されることを確認

https://claude.ai/code/session_015CRHwiikGD9jDtrzLDCNud

---
_Generated by [Claude Code](https://claude.ai/code/session_015CRHwiikGD9jDtrzLDCNud)_