### PR TITLE
fix(preview): プレビュー再生中の動画フェードアウトが急に黒落ちする不具合を修正

### DIFF
--- a/.agents/skills/turtle-video-overview/references/implementation-patterns.md
+++ b/.agents/skills/turtle-video-overview/references/implementation-patterns.md
@@ -157,6 +157,18 @@
   - Android 分岐に閉じる（iOS Safari / export ルートへ波及させない）
   - preroll 失敗時は warning を残して診断可能にする
 
+### 0-12. プレビュー再生中の video フェードアウト終端は黒クリア優先を無効化する
+
+- **ファイル**: `src/components/turtle-video/usePreviewEngine.ts`
+- **背景**:
+  - `shouldBlackoutVideoFadeTail` は終端の残像対策として有効だが、再生中にも適用するとフェードアウトが途中で急に黒へ落ち、プレビューで「徐々に消える」見え方が損なわれる
+  - 特にフェード長が短いクリップでは、終端保護の黒クリアが体感上ほぼ全量を上書きし、フェードが効いていないように見える
+- **実装指針**:
+  - `shouldSkipVideoDrawForFadeTail` は停止時/保持時（`!isActivePlaying`）に限定する
+  - 再生中は `ctx.globalAlpha` による通常フェード描画を維持し、終端残像対策だけを最小範囲に閉じる
+- **注意点**:
+  - 終端黒フレーム防止の既存ロジックは維持し、export や iOS/Android 分岐の挙動は変更しない
+
 ## 1. スクロール/スワイプ誤操作防止
 
 ### 1-1. モーダル表示時のボディスクロールロック

--- a/src/components/turtle-video/usePreviewEngine.ts
+++ b/src/components/turtle-video/usePreviewEngine.ts
@@ -823,7 +823,11 @@ export function usePreviewEngine({
             const shouldSkipVideoDrawForFadeTail =
               isVideo
               && id === activeId
-              && shouldBlackoutFadeTail;
+              && shouldBlackoutFadeTail
+              // フェード中のプレビュー再生では alpha で自然に減衰させる。
+              // 黒クリア優先は停止時/保持時のみ有効化し、
+              // 「フェードアウトが即座に黒へ落ちる」退行を防ぐ。
+              && !isActivePlaying;
 
             if (isReady && !shouldSkipVideoDrawForFadeTail) {
               const elemW = isVideo ? videoEl.videoWidth : imgEl.naturalWidth;


### PR DESCRIPTION
### Motivation
- プレビューでフェードアウトを設定した動画が再生中に終端保護の「黒クリア優先」ロジックで急に黒く落ち、`globalAlpha` による滑らかなフェードイン/フェードアウト表現が損なわれる問題を解消するための修正です。

### Description
- `src/components/turtle-video/usePreviewEngine.ts` の描画判定で、`shouldBlackoutFadeTail` による描画スキップを再生中は無効化するために `!isActivePlaying` 条件を追加しました（`shouldSkipVideoDrawForFadeTail` を限定）。
- 今回の修正方針と注意点を `.agents/skills/turtle-video-overview/references/implementation-patterns.md` に追記し、プレビュー描画の挙動範囲と export/iOS/Android 分岐へ波及させないことを明記しました。
- 変更はプレビュー描画ロジックの最小差分に限定しており、export やプラットフォーム固有ルートの挙動には影響を与えない前提で実装しています.

### Testing
- ユニットテストを実行したコマンド `npm run test:run -- src/test/standardPreviewEngine.test.tsx` は 37 件すべて合格しました（`37 passed`）。
- ビルドを `npm run build` で実行し、TypeScript コンパイルと Vite ビルドが成功しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c539ace488325ae50308593695fe5)