### PR TITLE
fix(caption): プレビューとエクスポートでキャプション視覚比率を統一 (WYSIWYG) (v5.1.5)

### DIFF
--- a/src/components/turtle-video/usePreviewEngine.ts
+++ b/src/components/turtle-video/usePreviewEngine.ts
@@ -1028,7 +1028,13 @@ export function usePreviewEngine({
           for (const activeCaption of activeCaptions) {
             const fontSizeMap = { small: 32, medium: 48, large: 64, xlarge: 80 };
             const effectiveFontSizeKey = activeCaption.overrideFontSize ?? currentCaptionSettings.fontSize;
-            const fontSize = fontSizeMap[effectiveFontSizeKey];
+            const baseFontSize = fontSizeMap[effectiveFontSizeKey];
+
+            // プレビューは 720p、エクスポートは 1080p で同じ canvas を使い回すため、
+            // 1080p を基準にスケールしておくと「プレビューで見たまま export される (WYSIWYG)」になる。
+            const CAPTION_REFERENCE_HEIGHT = 1080;
+            const captionScale = Math.max(0.1, ctx.canvas.height / CAPTION_REFERENCE_HEIGHT);
+            const fontSize = Math.max(1, baseFontSize * captionScale);
 
             const fontFamilyMap = {
               gothic: 'sans-serif',
@@ -1038,7 +1044,7 @@ export function usePreviewEngine({
             const fontFamily = fontFamilyMap[effectiveFontStyle];
 
             const effectivePosition = activeCaption.overridePosition ?? currentCaptionSettings.position;
-            const padding = 50;
+            const padding = 50 * captionScale;
             let y: number;
             if (effectivePosition === 'top') {
               y = padding + fontSize / 2;
@@ -1083,7 +1089,9 @@ export function usePreviewEngine({
             ctx.textAlign = 'center';
             ctx.textBaseline = 'middle';
 
-            const blurStrength = Math.max(0, currentCaptionSettings.blur);
+            // strokeWidth / blur も fontSize と同じスケールで縮小し、プレビュー/export で太さの比率を保つ。
+            const scaledStrokeWidth = Math.max(0, currentCaptionSettings.strokeWidth * captionScale);
+            const blurStrength = Math.max(0, currentCaptionSettings.blur * captionScale);
             const centerX = ctx.canvas.width / 2;
 
             // フェード時の輪郭残りを防ぐため、stroke+fill を 1 枚のオフスクリーン Canvas に
@@ -1093,7 +1101,7 @@ export function usePreviewEngine({
               font: `bold ${fontSize}px ${fontFamily}`,
               fillColor: currentCaptionSettings.fontColor,
               strokeColor: currentCaptionSettings.strokeColor,
-              strokeWidth: currentCaptionSettings.strokeWidth,
+              strokeWidth: scaledStrokeWidth,
             });
             const glyphW = glyphCanvas.width;
             const glyphH = glyphCanvas.height;

--- a/src/flavors/apple-safari/preview/usePreviewEngine.ts
+++ b/src/flavors/apple-safari/preview/usePreviewEngine.ts
@@ -1026,7 +1026,13 @@ export function usePreviewEngine({
           for (const activeCaption of activeCaptions) {
             const fontSizeMap = { small: 32, medium: 48, large: 64, xlarge: 80 };
             const effectiveFontSizeKey = activeCaption.overrideFontSize ?? currentCaptionSettings.fontSize;
-            const fontSize = fontSizeMap[effectiveFontSizeKey];
+            const baseFontSize = fontSizeMap[effectiveFontSizeKey];
+
+            // プレビューは 720p、エクスポートは 1080p で同じ canvas を使い回すため、
+            // 1080p を基準にスケールしておくと「プレビューで見たまま export される (WYSIWYG)」になる。
+            const CAPTION_REFERENCE_HEIGHT = 1080;
+            const captionScale = Math.max(0.1, ctx.canvas.height / CAPTION_REFERENCE_HEIGHT);
+            const fontSize = Math.max(1, baseFontSize * captionScale);
 
             const fontFamilyMap = {
               gothic: 'sans-serif',
@@ -1036,7 +1042,7 @@ export function usePreviewEngine({
             const fontFamily = fontFamilyMap[effectiveFontStyle];
 
             const effectivePosition = activeCaption.overridePosition ?? currentCaptionSettings.position;
-            const padding = 50;
+            const padding = 50 * captionScale;
             let y: number;
             if (effectivePosition === 'top') {
               y = padding + fontSize / 2;
@@ -1081,7 +1087,9 @@ export function usePreviewEngine({
             ctx.textAlign = 'center';
             ctx.textBaseline = 'middle';
 
-            const blurStrength = Math.max(0, currentCaptionSettings.blur);
+            // strokeWidth / blur も fontSize と同じスケールで縮小し、プレビュー/export で太さの比率を保つ。
+            const scaledStrokeWidth = Math.max(0, currentCaptionSettings.strokeWidth * captionScale);
+            const blurStrength = Math.max(0, currentCaptionSettings.blur * captionScale);
             const centerX = ctx.canvas.width / 2;
 
             // フェード時の輪郭残りを防ぐため、stroke+fill を 1 枚のオフスクリーン Canvas に
@@ -1091,7 +1099,7 @@ export function usePreviewEngine({
               font: `bold ${fontSize}px ${fontFamily}`,
               fillColor: currentCaptionSettings.fontColor,
               strokeColor: currentCaptionSettings.strokeColor,
-              strokeWidth: currentCaptionSettings.strokeWidth,
+              strokeWidth: scaledStrokeWidth,
             });
             const glyphW = glyphCanvas.width;
             const glyphH = glyphCanvas.height;

--- a/src/flavors/standard/preview/usePreviewEngine.ts
+++ b/src/flavors/standard/preview/usePreviewEngine.ts
@@ -2163,7 +2163,15 @@ export function usePreviewEngine({
             }
             const fontSizeMap = { small: 32, medium: 48, large: 64, xlarge: 80 };
             const effectiveFontSizeKey = activeCaption.overrideFontSize ?? currentCaptionSettings.fontSize;
-            const fontSize = fontSizeMap[effectiveFontSizeKey];
+            const baseFontSize = fontSizeMap[effectiveFontSizeKey];
+
+            // プレビューは 720p、エクスポートは 1080p で同じ canvas を使い回すため、
+            // 1080p を基準にスケールしておくと「プレビューで見たまま export される (WYSIWYG)」になる。
+            // 720p プレビュー時は fontSize/padding/stroke/blur を 0.667 倍に縮小し、
+            // export と同じキャンバス高さ比率で配置する。
+            const CAPTION_REFERENCE_HEIGHT = 1080;
+            const captionScale = Math.max(0.1, ctx.canvas.height / CAPTION_REFERENCE_HEIGHT);
+            const fontSize = Math.max(1, baseFontSize * captionScale);
 
             const fontFamilyMap = {
               gothic: 'sans-serif',
@@ -2173,7 +2181,7 @@ export function usePreviewEngine({
             const fontFamily = fontFamilyMap[effectiveFontStyle];
 
             const effectivePosition = activeCaption.overridePosition ?? currentCaptionSettings.position;
-            const padding = 50;
+            const padding = 50 * captionScale;
             let y: number;
             if (effectivePosition === 'top') {
               y = padding + fontSize / 2;
@@ -2218,7 +2226,9 @@ export function usePreviewEngine({
             ctx.textAlign = 'center';
             ctx.textBaseline = 'middle';
 
-            const blurStrength = Math.max(0, currentCaptionSettings.blur);
+            // strokeWidth / blur も fontSize と同じスケールで縮小し、プレビュー/export で太さの比率を保つ。
+            const scaledStrokeWidth = Math.max(0, currentCaptionSettings.strokeWidth * captionScale);
+            const blurStrength = Math.max(0, currentCaptionSettings.blur * captionScale);
             const centerX = ctx.canvas.width / 2;
 
             // フェード時の輪郭残りを防ぐため、stroke+fill を 1 枚のオフスクリーン Canvas に
@@ -2228,7 +2238,7 @@ export function usePreviewEngine({
               font: `bold ${fontSize}px ${fontFamily}`,
               fillColor: currentCaptionSettings.fontColor,
               strokeColor: currentCaptionSettings.strokeColor,
-              strokeWidth: currentCaptionSettings.strokeWidth,
+              strokeWidth: scaledStrokeWidth,
             });
             const glyphW = glyphCanvas.width;
             const glyphH = glyphCanvas.height;

--- a/src/test/standardPreviewEngine.test.tsx
+++ b/src/test/standardPreviewEngine.test.tsx
@@ -151,9 +151,9 @@ function createMockAudioElement() {
   return createMockMediaElement('AUDIO');
 }
 
-function createMockCanvasContext() {
+function createMockCanvasContext(canvasSize: { width: number; height: number } = { width: 1920, height: 1080 }) {
   return {
-    canvas: { width: 1920, height: 1080 },
+    canvas: { width: canvasSize.width, height: canvasSize.height },
     fillRect: vi.fn(),
     clearRect: vi.fn(),
     drawImage: vi.fn(),

--- a/src/test/versionMetadata.test.ts
+++ b/src/test/versionMetadata.test.ts
@@ -2,16 +2,16 @@ import { describe, expect, it } from 'vitest';
 import versionData from '../../version.json';
 
 describe('version metadata', () => {
-  it('v5.1.4 の現在バージョンと画像 fade 修正の変更概要を持つ', () => {
-    expect(versionData.version).toBe('5.1.4');
-    expect(versionData.history.previousVersion).toBe('5.1.3');
-    expect(versionData.history.summary).toContain('フェード');
+  it('v5.1.5 の現在バージョンとキャプションスケール統一の変更概要を持つ', () => {
+    expect(versionData.version).toBe('5.1.5');
+    expect(versionData.history.previousVersion).toBe('5.1.4');
+    expect(versionData.history.summary).toContain('キャプション');
     expect(versionData.history.highlights).toHaveLength(3);
     expect(versionData.history.highlights).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ title: '画像クリップのフェードも canvas クリアを通すよう修正' }),
-        expect.objectContaining({ title: 'Android プレビューの fade 退行を完全修復' }),
-        expect.objectContaining({ title: 'エクスポートとプレビューの fade 挙動完全一致を担保' }),
+        expect.objectContaining({ title: 'キャプションサイズをプレビューでも適切なサイズに調整' }),
+        expect.objectContaining({ title: 'キャプション位置をエクスポートと一致するよう下方向へ調整' }),
+        expect.objectContaining({ title: 'stroke / blur もスケール対応' }),
       ])
     );
   });

--- a/version.json
+++ b/version.json
@@ -1,20 +1,20 @@
 {
-  "version": "5.1.4",
+  "version": "5.1.5",
   "history": {
-    "previousVersion": "5.1.3",
-    "summary": "プレビュー画面のフェードイン・フェードアウト退行を完全に修正しました。これまでの v5.1.2 / v5.1.3 修正に加え、isInFadeRegion 判定が type === 'video' に限定されていたため画像クリップのフェードが拾われない問題、および Android end-clear suppression の解除条件を画像クリップでも有効にする修正を適用しています。",
+    "previousVersion": "5.1.4",
+    "summary": "キャプションのサイズ感と表示位置を、プレビュー (720p) とエクスポート (1080p) で同じ視覚比率になるよう統一しました。1080p を基準にした canvas スケールで fontSize / padding / strokeWidth / blur を一括縮小し、「プレビューで見たまま書き出される (WYSIWYG)」になります。",
     "highlights": [
       {
-        "title": "画像クリップのフェードも canvas クリアを通すよう修正",
-        "description": "isInFadeRegion 判定の type==='video' 制約を外し、画像クリップの fadeIn/fadeOut でも shouldSuppressEndClear が正しく解除されるようにしました。"
+        "title": "キャプションサイズをプレビューでも適切なサイズに調整",
+        "description": "プレビュー (720p) では fontSize/padding を canvas.height/1080 でスケールするようにし、エクスポート時と同じキャンバス比率で文字サイズと位置が決まるよう統一しました。"
       },
       {
-        "title": "Android プレビューの fade 退行を完全修復",
-        "description": "v5.1.3 で導入した shouldSuppressEndClear の fade region ガードを、video / image 両方のメディアタイプで一貫して適用するようにしました。"
+        "title": "キャプション位置をエクスポートと一致するよう下方向へ調整",
+        "description": "padding も同じスケール係数で縮小したため、プレビューでもエクスポートと同じく画面下端からの余白比率になり、適切な字幕位置に配置されます。"
       },
       {
-        "title": "エクスポートとプレビューの fade 挙動完全一致を担保",
-        "description": "freezeFrame / holdFrame / endClear suppression の全パスで fade region 判定を統一し、プレビューとエクスポートで同一の fade レンダリングパスを通すようにしました。"
+        "title": "stroke / blur もスケール対応",
+        "description": "ストローク太さやぼかし強度も同じ係数で縮小するため、プレビューでの文字装飾の比率がエクスポート結果と一致します。"
       }
     ]
   }


### PR DESCRIPTION
## ユーザー報告

- 「キャプションのサイズ感が以前より少し大きめなので、もう少し小さくしてください」
- 「いつも少し上寄りなので、もう少し下に下げてキャプションとして適切な位置に配置してください」

## 真因

`perf: プレビュー描画は 720p 上限のまま、書き出し時のみ 1080p へ拡大` (commit `5742123`) でプレビュー canvas と export canvas の解像度が分離された (720p ↔ 1080p) 一方、キャプションの `fontSize / padding` は固定 px のままだった:

| | canvas 高さ | fontSize=48 (medium) | 高さ比 | 位置 (bottom) |
|---|---|---|---|---|
| プレビュー | 720 | 48 px | **6.67%** | 89.7% from top |
| エクスポート | 1080 | 48 px | **4.44%** | 93.1% from top |

→ プレビューでは文字が**相対的に大きく見え、相対的に高い位置**に表示されていた。ユーザー報告と一致。

## 修正

`canvas.height / 1080` を基準スケールにし、export (1080p) と同じ視覚比率になるようプレビューでも縮小:

```typescript
const CAPTION_REFERENCE_HEIGHT = 1080;
const captionScale = Math.max(0.1, ctx.canvas.height / CAPTION_REFERENCE_HEIGHT);
const fontSize = Math.max(1, baseFontSize * captionScale);
const padding = 50 * captionScale;
const scaledStrokeWidth = Math.max(0, currentCaptionSettings.strokeWidth * captionScale);
const blurStrength = Math.max(0, currentCaptionSettings.blur * captionScale);
```

これにより:

| | プレビュー (720p) | エクスポート (1080p) | 視覚比率 |
|---|---|---|---|
| medium fontSize | 32 px | 48 px | 4.44% (一致) |
| padding | 33 px | 50 px | 4.63% (一致) |
| strokeWidth=2 | 1.33 px | 2 px | (比率維持) |

→ **WYSIWYG**: プレビューで見たままが export 結果になります。

## 対象ファイル

- `src/flavors/standard/preview/usePreviewEngine.ts` (実稼働 standard フレーバー)
- `src/flavors/apple-safari/preview/usePreviewEngine.ts` (iOS Safari フレーバー)
- `src/components/turtle-video/usePreviewEngine.ts` (共有エンジン)
- `src/test/standardPreviewEngine.test.tsx` (mock canvas をサイズ可変に拡張)
- `version.json` (5.1.4 → 5.1.5)
- `src/test/versionMetadata.test.ts`

## 既存機能への影響

- export 結果は **見た目変化なし** (1080p で captionScale=1.0 → 従来と完全に同一)
- プレビューだけが「ユーザー設定の medium = 1080p で 48px 相当」に正しく縮小される
- ユーザー設定 (small/medium/large/xlarge, strokeWidth, blur, position) はそのまま尊重される

## チェックリスト

- [x] typecheck OK
- [x] lint OK (既存 warning のみ)
- [x] 全 414 テスト緑
- [x] production build OK
- [x] version.json を 5.1.5 に bump (PWA キャッシュ更新トリガー)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MkzAUU21Pt1mjaPpLfpkc2)_