### PR TITLE
fix(preview): iOS Safari 境界キックで currentTime を触らない (映像が固まり音だけ流れる退行を解消) (v5.1.12)

### DIFF
--- a/src/flavors/apple-safari/preview/usePreviewEngine.ts
+++ b/src/flavors/apple-safari/preview/usePreviewEngine.ts
@@ -729,17 +729,20 @@ export function usePreviewEngine({
               }
 
               // iOS Safari の動画→動画 / 画像→動画 境界では、新しい active video が
-              // 「paused のまま readyState=0/1」の状態に取り残されることがある。
-              // 後続フレームの synchronous play() は readyState >= 1 を要求するため、
-              // メタデータ未到達の瞬間に取りこぼされると、canvas は holdFrame で前フレームを
-              // 維持するか、最終的に黒クリアされたまま固まる退行が発生する。
-              // 境界の瞬間だけ、load → seek → 準備でき次第 play() を 1 回キックして
-              // synchronous ループへ合流させる。Standard (Android/PC) には影響しない。
+              // 「paused のまま readyState=0/1」の状態に取り残され、後続フレームの
+              // synchronous play() (readyState >= 1 必須) を取りこぼして黒画面で
+              // 固まる退行が発生する。境界の瞬間に paused 状態の場合だけ play() を
+              // キックする。currentTime は触らない（プレイ中の動画の currentTime を
+              // 上書きすると iOS Safari が seeking=true のまま戻らず、音は鳴るのに
+              // 映像が前フレームで固まる退行を引き起こす）。シーク同期は既存の
+              // prebuffer block (line 652-672) と既存 sync block に任せる。
+              // Standard (Android/PC) には影響しない。
               if (
                 becameActiveOnThisFrame
                 && platformCapabilities.isIosSafari
                 && !_isExporting
                 && !isSeekingRef.current
+                && videoEl.paused
               ) {
                 const scheduledAttempt = previewPlaybackAttemptRef.current;
                 const attemptBoundaryPlay = () => {
@@ -758,16 +761,13 @@ export function usePreviewEngine({
                   }
                 };
 
-                if (Math.abs(videoEl.currentTime - targetTime) > 0.1) {
-                  try { videoEl.currentTime = targetTime; } catch { /* ignore */ }
-                }
-
-                if (!videoEl.seeking && videoEl.readyState >= 1 && videoEl.paused) {
+                if (!videoEl.seeking && videoEl.readyState >= 1) {
                   attemptBoundaryPlay();
                 }
 
-                // メタデータ未到達 / seek 中の場合に備え、最初に届いた準備完了イベントで
-                // 1 回だけ play() を試みる。{ once: true } で自然にクリーンアップされる。
+                // readyState が 0/1 で seek 中のとき向けに、最初に届いた準備完了
+                // イベントで 1 回だけ play() を試みる。{ once: true } で自然に
+                // クリーンアップされ、すでに playing 中の動画には影響しない。
                 videoEl.addEventListener('loadedmetadata', attemptBoundaryPlay, { once: true });
                 videoEl.addEventListener('loadeddata', attemptBoundaryPlay, { once: true });
                 videoEl.addEventListener('canplay', attemptBoundaryPlay, { once: true });

--- a/src/test/appleSafariPreviewEngineBoundary.test.tsx
+++ b/src/test/appleSafariPreviewEngineBoundary.test.tsx
@@ -429,4 +429,42 @@ describe('apple-safari preview engine boundary kick', () => {
       logInfo.mock.calls.some(([, message]) => message === 'iOS Safari preview video 境界キック'),
     ).toBe(false);
   });
+
+  it('prewarm 済みで既に再生中の動画には境界キックを掛けない (currentTime も触らない)', () => {
+    const video1 = createVideoItem({ id: 'v1', duration: 2 });
+    const video2 = createVideoItem({ id: 'v2', duration: 2 });
+    const video1El = createMockVideoElement();
+    const video2El = createMockVideoElement();
+    video1El.readyState = 4;
+    video1El.paused = false;
+    // v2 は無音 prewarm で既に paused=false / readyState=4 / currentTime が trimStart より先へ進んだ状態。
+    // BGM 経路で active 化前に silent-play されたケースを模す。
+    video2El.readyState = 4;
+    video2El.paused = false;
+    video2El.currentTime = 0.35;
+
+    const activeVideoIdRef = createRef<string | null>('v1');
+
+    const { hook, logInfo } = setupRenderFrameHarness({
+      mediaItems: [video1, video2],
+      mediaElements: {
+        [video1.id]: video1El as unknown as HTMLVideoElement,
+        [video2.id]: video2El as unknown as HTMLVideoElement,
+      } as MediaElementsRef,
+      activeVideoIdRef,
+    });
+
+    hook.result.current.renderFrame(2.05, true, false);
+
+    // 既に再生中なので追加の play() は呼ばない、currentTime も上書きしない、
+    // リスナーも仕掛けない。currentTime の上書きは iOS Safari で seeking=true のまま
+    // 戻らず、音だけ鳴って映像が固まる退行を引き起こすため避ける。
+    expect(video2El.play).not.toHaveBeenCalled();
+    expect(video2El.currentTime).toBeCloseTo(0.35);
+    expect(video2El.listenerCount('canplay')).toBe(0);
+    expect(video2El.listenerCount('seeked')).toBe(0);
+    expect(
+      logInfo.mock.calls.some(([, message]) => message === 'iOS Safari preview video 境界キック'),
+    ).toBe(false);
+  });
 });

--- a/src/test/versionMetadata.test.ts
+++ b/src/test/versionMetadata.test.ts
@@ -2,22 +2,22 @@ import { describe, expect, it } from 'vitest';
 import versionData from '../../version.json';
 
 describe('version metadata', () => {
-  it('v5.1.11 の現在バージョンと iOS Safari 動画境界の黒画面修正の変更概要を持つ', () => {
-    expect(versionData.version).toBe('5.1.11');
-    expect(versionData.history.previousVersion).toBe('5.1.10');
-    expect(versionData.history.summary).toContain('iPhone');
+  it('v5.1.12 の現在バージョンと iOS Safari 境界キック currentTime 上書き修正の変更概要を持つ', () => {
+    expect(versionData.version).toBe('5.1.12');
+    expect(versionData.history.previousVersion).toBe('5.1.11');
     expect(versionData.history.summary).toContain('iOS Safari');
+    expect(versionData.history.summary).toContain('currentTime');
     expect(versionData.history.highlights).toHaveLength(3);
     expect(versionData.history.highlights).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          title: 'iOS Safari の動画→動画境界で 2 本目以降が黒画面のまま固まる退行を修正',
+          title: 'iOS Safari 境界キックで currentTime を触らないように修正 (映像が固まり音だけ流れる退行を回避)',
         }),
         expect.objectContaining({
-          title: 'iOS Safari の画像→動画境界でも同じ取りこぼしを救済',
+          title: '境界キックを paused 状態の video に限定 (prewarm 済みの再生中動画への干渉を排除)',
         }),
         expect.objectContaining({
-          title: 'Android/PC プレビューには影響しない iOS Safari 専用修正',
+          title: 'Android/PC プレビューには変更なし (apple-safari flavor 内でのみ完結)',
         }),
       ])
     );

--- a/version.json
+++ b/version.json
@@ -1,20 +1,20 @@
 {
-  "version": "5.1.11",
+  "version": "5.1.12",
   "history": {
-    "previousVersion": "5.1.10",
-    "summary": "iPhone/iPad Safari でプレビュー再生時に「2 本目以降の動画」や「動画→画像→動画」の組み合わせで 2 本目の動画が真っ黒のまま再生されない退行を修正しました。動画→動画の境界で新しい動画の読み込み完了を待ってから再生するキックを 1 回だけ仕掛けるようにし、メタデータ未到達で取りこぼされるケースを防いでいます。修正の影響は iOS Safari 経路のみで、Android/PC のプレビュー処理には変更を入れていません。",
+    "previousVersion": "5.1.11",
+    "summary": "v5.1.11 で導入した iOS Safari 動画境界キックが、新しい active video の currentTime を上書きすることで「音は鳴るのに映像が固まる」副作用を引き起こしていたため、キックの方針を見直しました。境界の瞬間に video が paused 状態のときだけ play() を仕掛けるようにし、currentTime の上書きは行わないようにしました。Standard (Android/PC) には引き続き影響を与えていません。",
     "highlights": [
       {
-        "title": "iOS Safari の動画→動画境界で 2 本目以降が黒画面のまま固まる退行を修正",
-        "description": "iPhone/iPad Safari のプレビュー再生で、2 本目の動画に切り替わる瞬間に readyState がまだ低いと後続フレームの自動 play() に取りこぼされ、画面が黒いまま固まる事象を修正しました。境界の瞬間にだけ load → seek → 準備でき次第 play() するキックを 1 度だけ仕掛けて取りこぼしを救済します。"
+        "title": "iOS Safari 境界キックで currentTime を触らないように修正 (映像が固まり音だけ流れる退行を回避)",
+        "description": "v5.1.11 で導入した境界キックが、新しい active video の currentTime を targetTime に揃え直していたため、iOS Safari 側で seeking=true のまま戻らず「音は鳴るのに映像が前フレームで固まる」退行を発生させていました。境界キックは play() のみ仕掛け、シーク同期は既存の prebuffer block と sync block に任せるよう責務を分離しました。"
       },
       {
-        "title": "iOS Safari の画像→動画境界でも同じ取りこぼしを救済",
-        "description": "動画→画像→動画 のような複合的な並びでも、画像区間明けの動画が同様に黒画面で固まることがあったため、同じ境界キックで救済対象に含めています。"
+        "title": "境界キックを paused 状態の video に限定 (prewarm 済みの再生中動画への干渉を排除)",
+        "description": "BGM 等のあるシーンで video2 が無音 prewarm で既に再生中になっているケースで、境界キックが余計な play() / リスナー追加を実行しないようガードを追加しました。これにより prewarm 済みの再生中の video には境界キックがまったく介入しません。"
       },
       {
-        "title": "Android/PC プレビューには影響しない iOS Safari 専用修正",
-        "description": "本修正は apple-safari flavor のプレビューエンジンの中だけで完結しており、Android/PC で動いている standard flavor の挙動には変更が入っていません。境界キックは isIosSafari かつ非エクスポート時のみ発火します。"
+        "title": "Android/PC プレビューには変更なし (apple-safari flavor 内でのみ完結)",
+        "description": "本修正は src/flavors/apple-safari/preview/usePreviewEngine.ts のみを変更しており、Android/PC で動いている standard flavor の挙動には変更が入っていません。境界キックは isIosSafari かつ非エクスポート時のみ発火します。"
       }
     ]
   }


### PR DESCRIPTION
## 概要

v5.1.11 (PR #197) で導入した iOS Safari 動画境界キックの副作用を修正します。

実機テストで「2 本目の動画は **黒画面** から **音は鳴るのに映像が前フレームで固まる**」状態に部分的に改善した一方で、まだ映像が動かない退行が残っていました。原因は、境界キックが新しい active video の `currentTime` を `targetTime` に揃え直していたことで、iOS Safari 側で `seeking=true` のまま戻らず、音は鳴るのに映像が更新されない状態になっていたためです。

## 修正内容

`src/flavors/apple-safari/preview/usePreviewEngine.ts` の境界キックを以下のように再設計しました。

- **`currentTime` の上書きを廃止**: 境界キックでは seek を起こさないようにし、iOS Safari の seeking=true 滞留を回避。シーク同期は既存の prebuffer block (line 652-672) と既存 sync block (syncThreshold=1.0s) に任せる。
- **境界キックを `paused=true` の video に限定**: prewarm で既に再生中の動画 (BGM があるケース等で silent-play している video) には一切介入しないようガード追加。これにより prewarm 済みの再生中動画への余計な `play()` / リスナー追加を排除。
- **準備イベントリスナー**は引き続き `paused` のときだけ 1 度仕掛けて、`readyState=0/1` で synchronous play() が取りこぼされたときの救済として動作。

## 影響範囲

- 修正対象: `src/flavors/apple-safari/preview/usePreviewEngine.ts` のみ
- Android/PC の `standard` preview engine には変更を入れていません
- 境界キックは `isIosSafari && !isExporting && !isSeeking && videoEl.paused` のときのみ発火します

## テスト

- `appleSafariPreviewEngineBoundary.test.tsx` に 1 件追加 (prewarm 済みで再生中の動画にはキックを掛けず currentTime も触らないことを保証)
- 全 421 件 (52 ファイル) のテストが pass
- `npm run build` 通過

## 残課題

実機テストで「BGM ありで video1 から音が鳴らない / video2 ブラックアウト」も報告されていますが、コード解析だけでは原因を特定できていません。v5.1.12 で freeze 退行を取り除いた後で再度実機確認をお願いします。

## Test plan

- [ ] iPhone Safari で動画 2 本のプレビュー再生 → 2 本目が映像も音声も再生されることを確認
- [ ] iPhone Safari で動画→画像→動画 のプレビュー再生 → 3 本目が再生されることを確認
- [ ] iPhone Safari で BGM ありシナリオを再確認し、まだ音が出ない / ブラックアウトする問題が残っていればログ (preview/audio) を共有
- [ ] Android プレビューに退行が出ていないことを確認

https://claude.ai/code/session_01Wo972ALf8zvAwMnfiYJEW6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wo972ALf8zvAwMnfiYJEW6)_