### PR TITLE
fix(export): iOS Safari の export 完了でダウンロードボタンへ切り替え + UI 文言整備 (v5.1.15)

### DIFF
--- a/Docs/2026-05-23_ios-safari-preview-stabilization-overview.md
+++ b/Docs/2026-05-23_ios-safari-preview-stabilization-overview.md
@@ -1,0 +1,118 @@
+# iOS Safari プレビュー安定化 オーバービュー (v5.1.11 → v5.1.14)
+
+**作成日**: 2026-05-23
+**対象バージョン**: v5.1.11 〜 v5.1.14
+**ステータス**: ✅ プレビュー安定動作確認済み (実機テスト) — この動作を維持する
+
+## 1. このドキュメントの目的
+
+iPhone / iPad Safari (`apple-safari` flavor) のプレビュー再生がようやく
+安定動作に到達したため、その「現状の動作」を維持基準として保存する。
+今後 standard flavor 側の改修や apple-safari の export 側修正を行う際は、
+**ここに記載された preview 経路には触れない / 機能保持を回帰テストで担保する**。
+
+## 2. 安定動作確認済みのシナリオ (実機)
+
+| シナリオ | 期待動作 | 確認結果 |
+| --- | --- | --- |
+| 動画 1 本のプレビュー再生 | 映像と音声が再生される | ✅ |
+| 動画 2 本のプレビュー再生 (BGM 無し) | 1 本目・2 本目とも映像・音声が再生される | ✅ |
+| 動画 → 画像 → 動画 のプレビュー再生 | 各クリップ区間で映像・音声が再生される | ✅ |
+| 動画→動画 境界 | 「黒画面」「映像 freeze + 音だけ」の退行が無い | ✅ |
+| 動画→動画 境界の音声 | 立ち上がり ~50ms 程度の短い音声ギャップは許容 | ✅ |
+
+> **注**: BGM ありシナリオは引き続き要実機確認 (本ドキュメント執筆時点)。
+> BGM 関連の修正・調整を入れる場合は、上記の動画単独シナリオが退行しないことを
+> 必ず先に保証する。
+
+## 3. 維持すべき主要な実装ポイント
+
+iOS Safari preview の安定動作は、v5.1.11 〜 v5.1.14 にかけて積み上げた
+次の 4 つの修正の組み合わせで成立している。**これらは単独ではなく
+組み合わせて初めて成立する**ため、個別に rollback すると退行する。
+
+### 3.1 動画境界の play() キック (v5.1.11 起点 / v5.1.12 で安定化)
+
+- 場所: `src/flavors/apple-safari/preview/usePreviewEngine.ts`
+  内の active video branch (`renderFrame` 内、`becameActiveOnThisFrame` 判定)
+- 役割: active video が切り替わったフレームで `paused` 状態の video に
+  対して `play()` を 1 度キックする。preparation event listener
+  (`loadedmetadata` / `loadeddata` / `canplay` / `seeked`) を `{ once: true }`
+  で仕掛け、`readyState=0/1` 取りこぼしを救済する。
+- **触ってはいけない条件**:
+  - `currentTime` を上書きしない (seek すると iOS Safari で `seeking=true`
+    のまま戻らず映像 freeze 退行が起きる)
+  - 既に再生中 (`paused=false`) の video には介入しない
+  - export 中 (`_isExporting=true`)・ユーザーシーク中 (`isSeekingRef.current`)
+    では発火しない
+
+### 3.2 BGM 無し単独動画でも WebAudio 経路を強制 (v5.1.13)
+
+- 場所: `src/flavors/apple-safari/preview/previewPlatform.ts`
+  内の `getPreviewAudioOutputMode`
+- 役割: iOS Safari (`policy.muteNativeMediaWhenAudioRouted=true`) では、
+  `audibleSourceCount=1` の単独動画でも `'webaudio'` を返し、
+  `ensureAudioNodeForElement` 経由で WebAudio 経路を確立させる。
+- **背景**: iOS Safari は `AudioContext` が `running` 状態のとき、
+  `createMediaElementSource()` で WebAudio に接続していない
+  `HTMLMediaElement` の native audio を暗黙に抑制する挙動が観測される。
+  WebAudio 経路を経由しないと、BGM 有無で音が出たり出なかったりする
+  不安定さが残る。
+- **触ってはいけない**: 単独動画で `'native'` に戻すと、BGM 無しシナリオで
+  音が出なくなる。
+
+### 3.3 silent prewarm の完全廃止 (v5.1.14)
+
+- 場所:
+  - `src/flavors/apple-safari/preview/previewPlatform.ts` の
+    `shouldPrimeFutureInactiveVideoInPreview` (全条件で `false` を返す)
+  - `src/flavors/apple-safari/preview/usePreviewEngine.ts` の
+    `startEngine` 内 startup prewarm ループ (`el.play()` 削除済み)
+- 役割: silent (`gain=0` / `native volume=0`) prewarm の `play()` を 2 経路
+  すべて廃止する。`currentTime` の位置合わせと audio 経路の確立
+  (`sourceNode` + `applyPreviewAudioOutputState`) のみ残す。
+- **背景**: iOS Safari は `createMediaElementSource()` 接続済みの video を
+  silent 再生すると、視覚フレームの decode を停止し「音は鳴るのに
+  1 フレーム目で映像が固まる」退行を引き起こす。
+- **触ってはいけない**: silent prewarm を再導入すると、v5.1.13 と同じ
+  映像 freeze 退行が再発する。再導入する場合は、`gain=0` ではなく
+  audible (例: `gain=0.001`) で prewarm するなどの代案検証が必要。
+
+### 3.4 active 化のタイミングで play() を担う単一経路
+
+- 上記 3.1 の境界キックが唯一の `play()` 起動経路となる。
+- silent prewarm が無いため、active 化直後の動画は `paused` 状態から
+  fresh `play()` で立ち上がる。立ち上がり (~50ms) の短い音声ギャップは
+  「動画と動画のつなぎ目で stutter を許容する」前提に合わせた割り切り。
+
+## 4. 回帰テスト (現時点で揃っているもの)
+
+| テストファイル | カバー範囲 |
+| --- | --- |
+| `src/test/appleSafariPreviewEngineBoundary.test.tsx` | 境界キックの発火条件、currentTime を触らないこと、export 中・seek 中は無効、prewarm 済みには介入しないこと |
+| `src/test/appleSafariFlavorRegression.test.ts` | 単独動画でも `'webaudio'` を返すこと、`shouldPrimeFutureInactiveVideoInPreview` が全条件で `false` を返すこと、video→image→video の future probe / single mix |
+| `src/test/previewRuntimeIsolation.test.ts` | standard と apple-safari の `getPreviewAudioOutputMode` が単独動画で異なる値を返すこと (`'native'` vs `'webaudio'`) |
+
+## 5. 影響範囲の境界
+
+| 領域 | 変更可否 |
+| --- | --- |
+| `src/flavors/apple-safari/preview/` | プレビューの維持を目的とする限定的な改修のみ。回帰テスト先 |
+| `src/flavors/apple-safari/export/` | preview に影響しない限り変更可 |
+| `src/flavors/standard/preview/` | 元々 silent prewarm を実行しない (`muteNativeMediaWhenAudioRouted=false`) ため iOS Safari の修正は届かない。standard 単独の改修は可 |
+| `src/components/sections/PreviewSection.tsx` (UI) | 操作系の変更は可。ただし `isProcessing` / `exportUrl` の state 駆動ロジックは preview 経由の発火条件と整合 |
+
+## 6. 残課題
+
+- BGM ありシナリオの実機受け入れ (本ドキュメント時点で部分的に未完了)
+- Export 完了時の UI 状態同期 (Android と同じく緑のダウンロードボタンへ
+  切り替わるかどうかの実機確認)
+
+## 7. 参考コミット
+
+| バージョン | コミット | 内容 |
+| --- | --- | --- |
+| v5.1.11 | `03a999f` | 動画→動画 / 画像→動画 境界キック導入 |
+| v5.1.12 | `277f5fc` | 境界キックで currentTime を触らない (映像 freeze 解消) |
+| v5.1.13 | `7e98a93` | 単独動画でも WebAudio 経路を強制 (音声不通解消) |
+| v5.1.14 | `22a57af` | silent prewarm を完全廃止 (映像 freeze 再発解消) |

--- a/src/app/appFlavorUi.ts
+++ b/src/app/appFlavorUi.ts
@@ -21,8 +21,8 @@ export interface SaveLoadRuntimeGuidance {
 export function getAppFlavorBadge(appFlavor: AppFlavor): AppFlavorBadge {
   if (appFlavor === 'apple-safari') {
     return {
-      label: 'Apple Safari 検証モード',
-      compactLabel: 'Safari検証',
+      label: 'Apple Safari 動作モード',
+      compactLabel: 'Safari動作',
       title: 'iPhone / iPad Safari 向けの安定動作優先モードです',
       className: 'border-amber-400/40 bg-amber-500/10 text-amber-200',
     };
@@ -50,22 +50,22 @@ export function getDownloadRouteInfo(input: {
   if (input.appFlavor === 'apple-safari') {
     return {
       label: 'ブラウザの共有・ダウンロード',
-      description: 'Apple Safari ではブラウザの共有メニューまたは標準ダウンロード導線を利用します。',
+      description: 'Apple Safari では、ブラウザの共有メニュー、または通常のダウンロード手順で保存します。',
     };
   }
 
   return {
     label: 'ブラウザの標準ダウンロード',
-    description: 'このブラウザでは標準ダウンロード導線を利用します。',
+    description: 'このブラウザでは通常のダウンロード手順で保存します。',
   };
 }
 
 export function getAppFlavorSupportSummary(appFlavor: AppFlavor): string {
   if (appFlavor === 'apple-safari') {
-    return 'iPhone / iPad の Safari は安定動作優先の検証モードです。基本編集・保存・書き出しを優先し、高度機能は標準モードが先行する場合があります。';
+    return 'iPhone / iPad の Safari は安定動作優先の動作モードです。基本編集・保存・書き出しを優先し、高度機能は標準モードが先行する場合があります。';
   }
 
-  return 'Android / PC は標準モードです。iPhone / iPad の Safari は安定動作を優先する検証中の系統として分離して扱います。高機能の改善はこの系統を先行し、保存や書き出しもブラウザ capability に応じて最適化されます。';
+  return 'Android / PC は標準モードです。iPhone / iPad の Safari は安定動作を優先する動作モードとして分離して扱います。高機能の改善はこの系統を先行し、保存や書き出しもブラウザ capability に応じて最適化されます。';
 }
 
 export function getDownloadHelpSentence(input: {
@@ -77,7 +77,7 @@ export function getDownloadHelpSentence(input: {
   }
 
   if (input.appFlavor === 'apple-safari') {
-    return 'Apple Safari 検証モードでは、ブラウザの共有メニューまたは標準ダウンロード導線を利用します。';
+    return 'Apple Safari 動作モードでは、ブラウザの共有メニュー、または通常のダウンロード手順で保存します。';
   }
 
   return 'このブラウザでは標準ダウンロードを利用します。';
@@ -92,10 +92,10 @@ export function getPreviewRuntimeNotice(input: {
   }
 
   return {
-    title: 'Apple Safari 検証モード',
+    title: 'Apple Safari 動作モード',
     description:
       'この環境では安定動作を優先します。書き出し中は画面を切り替えず、作成後の保存は '
-      + 'ブラウザの共有メニューまたは標準ダウンロード導線を利用してください。',
+      + 'ブラウザの共有メニュー、または通常のダウンロード手順をご利用ください。',
   };
 }
 
@@ -107,7 +107,7 @@ export function getSaveLoadRuntimeGuidance(input: {
 
   if (input.appFlavor === 'apple-safari') {
     return {
-      title: 'Apple Safari 検証モード',
+      title: 'Apple Safari 動作モード',
       summary:
         '保存データはブラウザ内に保持されます。Safari は通常タブ、ホーム画面追加、プライベートブラウズで保存領域が分かれる場合があります。',
       bullets: [

--- a/src/flavors/apple-safari/preview/usePreviewEngine.ts
+++ b/src/flavors/apple-safari/preview/usePreviewEngine.ts
@@ -1542,7 +1542,29 @@ export function usePreviewEngine({
 
     const hasActiveRecorder = !!(recorderRef.current && recorderRef.current.state !== 'inactive');
     if (hasActiveRecorder) {
-      recorderRef.current!.stop();
+      // iOS Safari の MediaRecorder.stop() は、事前に requestData() を呼んで
+      // バッファをフラッシュしないと、最後のチャンクが届かず onstop が発火しない
+      // ケースが実機テストで観測された。その結果「100% まで進んでもダウンロード
+      // ボタンに切り替わらない」退行になる。abort 経路と同じ「requestData() →
+      // 短い遅延 → stop()」の手順で呼び、確実に onstop と onRecordingStop
+      // コールバックを発火させる。
+      const recorder = recorderRef.current!;
+      try {
+        recorder.requestData();
+      } catch {
+        /* ignore */
+      }
+      // 180ms は abort 経路と同じ値。短すぎると iOS Safari でフラッシュが
+      // 間に合わないことがあるので、同じ間隔を採用する。
+      setTimeout(() => {
+        if (recorder.state !== 'inactive') {
+          try {
+            recorder.stop();
+          } catch {
+            /* ignore */
+          }
+        }
+      }, 180);
     } else {
       stopWebCodecsExport({ reason: 'user' });
     }

--- a/src/test/appleSafariPreviewEngineBoundary.test.tsx
+++ b/src/test/appleSafariPreviewEngineBoundary.test.tsx
@@ -467,4 +467,231 @@ describe('apple-safari preview engine boundary kick', () => {
       logInfo.mock.calls.some(([, message]) => message === 'iOS Safari preview video 境界キック'),
     ).toBe(false);
   });
+
+  it('export 中の stopAll は MediaRecorder に対し requestData() を呼んでから 180ms 遅延で stop() する', () => {
+    const video1 = createVideoItem({ id: 'v1', duration: 2 });
+    const video1El = createMockVideoElement();
+    video1El.readyState = 4;
+    video1El.paused = false;
+
+    // MediaRecorder のモック。iOS Safari は recorder.stop() の前に requestData() で
+    // バッファをフラッシュしないと onstop が発火しないため、stopAll() が
+    // 「requestData() → 180ms 遅延 → stop()」を実行することを確認する。
+    const recorderMock = {
+      state: 'recording' as RecordingState,
+      requestData: vi.fn(),
+      stop: vi.fn(() => {
+        recorderMock.state = 'inactive';
+      }),
+    };
+    const recorderRef = createRef<MediaRecorder | null>(
+      recorderMock as unknown as MediaRecorder,
+    );
+
+    const canvasContext = createMockCanvasContext();
+    const logInfo = vi.fn();
+    const logWarn = vi.fn();
+    const stopWebCodecsExport = vi.fn();
+    const platformCapabilities = getAppleSafariPreviewPlatformCapabilities(createCapabilities());
+    const previewPlatformPolicy = appleSafariPreviewRuntime.getPreviewPlatformPolicy(
+      platformCapabilities,
+    );
+
+    const hook = renderHook(() =>
+      usePreviewEngine({
+        captions: [] as Caption[],
+        captionSettings: { enabled: false } as unknown as CaptionSettings,
+        mediaItemsRef: createRef([video1]),
+        bgmRef: createRef<AudioTrack | null>(null),
+        narrationsRef: createRef<NarrationClip[]>([]),
+        captionsRef: createRef<Caption[]>([]),
+        captionSettingsRef: createRef({ enabled: false } as unknown as CaptionSettings),
+        totalDurationRef: createRef(2),
+        currentTimeRef: createRef(0),
+        canvasRef: createRef({
+          getContext: vi.fn(() => canvasContext),
+        } as unknown as HTMLCanvasElement),
+        mediaElementsRef: createRef({
+          [video1.id]: video1El as unknown as HTMLVideoElement,
+        } as MediaElementsRef),
+        audioCtxRef: createRef(null),
+        sourceNodesRef: createRef({}),
+        gainNodesRef: createRef({}),
+        masterDestRef: createRef(null),
+        audioRoutingModeRef: createRef<'preview' | 'export'>('export'),
+        reqIdRef: createRef<number | null>(null),
+        startTimeRef: createRef(0),
+        audioResumeWaitFramesRef: createRef(0),
+        recorderRef,
+        loopIdRef: createRef(1),
+        isPlayingRef: createRef(true),
+        isSeekingRef: createRef(false),
+        isSeekPlaybackPreparingRef: createRef(false),
+        activeVideoIdRef: createRef<string | null>('v1'),
+        videoRecoveryAttemptsRef: createRef({}),
+        exportPlayFailedRef: createRef({}),
+        exportFallbackSeekAtRef: createRef({}),
+        seekingVideosRef: createRef(new Set<string>()),
+        pendingSeekRef: createRef<number | null>(null),
+        wasPlayingBeforeSeekRef: createRef(false),
+        pendingSeekTimeoutRef: createRef<ReturnType<typeof setTimeout> | null>(null),
+        previewPlaybackAttemptRef: createRef(1),
+        requestPreviewAudioRouteRefreshRef: createRef(() => { }),
+        primePreviewAudioOnlyTracksAtTimeRef: createRef(() => { }),
+        endFinalizedRef: createRef(false),
+        previewPlatformPolicy,
+        platformCapabilities,
+        setVideoDuration: vi.fn(),
+        setCurrentTime: vi.fn(),
+        setProcessing: vi.fn(),
+        setLoading: vi.fn(),
+        setExportPreparationStep: vi.fn(),
+        setExportUrl: vi.fn(),
+        setExportExt: vi.fn(),
+        clearExport: vi.fn(),
+        setError: vi.fn(),
+        play: vi.fn(),
+        pause: vi.fn(),
+        getAudioContext: vi.fn(),
+        cancelPendingPausedSeekWait: vi.fn(),
+        cancelPendingSeekPlaybackPrepare: vi.fn(),
+        detachGlobalSeekEndListeners: vi.fn(),
+        ensureAudioNodeForElement: vi.fn(() => false),
+        detachAudioNode: vi.fn(),
+        preparePreviewAudioNodesForTime: vi.fn(() => ({
+          activeVideoId: null,
+          audibleSourceCount: 0,
+          requiresWebAudio: false,
+        })),
+        preparePreviewAudioNodesForUpcomingVideos: vi.fn(),
+        primePreviewAudioOnlyTracksAtTime: vi.fn(),
+        resetInactiveVideos: vi.fn(),
+        startWebCodecsExport: vi.fn(),
+        stopWebCodecsExport,
+        logInfo,
+        logWarn,
+        logDebug: vi.fn(),
+      }),
+    );
+
+    hook.result.current.stopAll();
+
+    // requestData() は即時に呼ばれる
+    expect(recorderMock.requestData).toHaveBeenCalledTimes(1);
+    // 180ms 経過前は stop() は呼ばれない
+    expect(recorderMock.stop).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(180);
+
+    // 180ms 後に stop() が呼ばれる
+    expect(recorderMock.stop).toHaveBeenCalledTimes(1);
+    // stopWebCodecsExport({ reason: 'user' }) は呼ばれない (callback suppression 回避のため)
+    expect(stopWebCodecsExport).not.toHaveBeenCalled();
+  });
+
+  it('stopAll は inactive な MediaRecorder には requestData/stop を呼ばず stopWebCodecsExport にフォールバックする', () => {
+    const video1 = createVideoItem({ id: 'v1', duration: 2 });
+    const video1El = createMockVideoElement();
+
+    const recorderMock = {
+      state: 'inactive' as RecordingState,
+      requestData: vi.fn(),
+      stop: vi.fn(),
+    };
+    const recorderRef = createRef<MediaRecorder | null>(
+      recorderMock as unknown as MediaRecorder,
+    );
+
+    const canvasContext = createMockCanvasContext();
+    const stopWebCodecsExport = vi.fn();
+    const platformCapabilities = getAppleSafariPreviewPlatformCapabilities(createCapabilities());
+    const previewPlatformPolicy = appleSafariPreviewRuntime.getPreviewPlatformPolicy(
+      platformCapabilities,
+    );
+
+    const hook = renderHook(() =>
+      usePreviewEngine({
+        captions: [] as Caption[],
+        captionSettings: { enabled: false } as unknown as CaptionSettings,
+        mediaItemsRef: createRef([video1]),
+        bgmRef: createRef<AudioTrack | null>(null),
+        narrationsRef: createRef<NarrationClip[]>([]),
+        captionsRef: createRef<Caption[]>([]),
+        captionSettingsRef: createRef({ enabled: false } as unknown as CaptionSettings),
+        totalDurationRef: createRef(2),
+        currentTimeRef: createRef(0),
+        canvasRef: createRef({
+          getContext: vi.fn(() => canvasContext),
+        } as unknown as HTMLCanvasElement),
+        mediaElementsRef: createRef({
+          [video1.id]: video1El as unknown as HTMLVideoElement,
+        } as MediaElementsRef),
+        audioCtxRef: createRef(null),
+        sourceNodesRef: createRef({}),
+        gainNodesRef: createRef({}),
+        masterDestRef: createRef(null),
+        audioRoutingModeRef: createRef<'preview' | 'export'>('preview'),
+        reqIdRef: createRef<number | null>(null),
+        startTimeRef: createRef(0),
+        audioResumeWaitFramesRef: createRef(0),
+        recorderRef,
+        loopIdRef: createRef(1),
+        isPlayingRef: createRef(true),
+        isSeekingRef: createRef(false),
+        isSeekPlaybackPreparingRef: createRef(false),
+        activeVideoIdRef: createRef<string | null>('v1'),
+        videoRecoveryAttemptsRef: createRef({}),
+        exportPlayFailedRef: createRef({}),
+        exportFallbackSeekAtRef: createRef({}),
+        seekingVideosRef: createRef(new Set<string>()),
+        pendingSeekRef: createRef<number | null>(null),
+        wasPlayingBeforeSeekRef: createRef(false),
+        pendingSeekTimeoutRef: createRef<ReturnType<typeof setTimeout> | null>(null),
+        previewPlaybackAttemptRef: createRef(1),
+        requestPreviewAudioRouteRefreshRef: createRef(() => { }),
+        primePreviewAudioOnlyTracksAtTimeRef: createRef(() => { }),
+        endFinalizedRef: createRef(false),
+        previewPlatformPolicy,
+        platformCapabilities,
+        setVideoDuration: vi.fn(),
+        setCurrentTime: vi.fn(),
+        setProcessing: vi.fn(),
+        setLoading: vi.fn(),
+        setExportPreparationStep: vi.fn(),
+        setExportUrl: vi.fn(),
+        setExportExt: vi.fn(),
+        clearExport: vi.fn(),
+        setError: vi.fn(),
+        play: vi.fn(),
+        pause: vi.fn(),
+        getAudioContext: vi.fn(),
+        cancelPendingPausedSeekWait: vi.fn(),
+        cancelPendingSeekPlaybackPrepare: vi.fn(),
+        detachGlobalSeekEndListeners: vi.fn(),
+        ensureAudioNodeForElement: vi.fn(() => false),
+        detachAudioNode: vi.fn(),
+        preparePreviewAudioNodesForTime: vi.fn(() => ({
+          activeVideoId: null,
+          audibleSourceCount: 0,
+          requiresWebAudio: false,
+        })),
+        preparePreviewAudioNodesForUpcomingVideos: vi.fn(),
+        primePreviewAudioOnlyTracksAtTime: vi.fn(),
+        resetInactiveVideos: vi.fn(),
+        startWebCodecsExport: vi.fn(),
+        stopWebCodecsExport,
+        logInfo: vi.fn(),
+        logWarn: vi.fn(),
+        logDebug: vi.fn(),
+      }),
+    );
+
+    hook.result.current.stopAll();
+
+    // recorder が inactive のときは MediaRecorder 経路には触れない
+    expect(recorderMock.requestData).not.toHaveBeenCalled();
+    expect(recorderMock.stop).not.toHaveBeenCalled();
+    // 通常停止 (preview 終了等) は従来通り stopWebCodecsExport にフォールバック
+    expect(stopWebCodecsExport).toHaveBeenCalledWith({ reason: 'user' });
+  });
 });

--- a/src/test/headerFlavorBadgePlacement.test.tsx
+++ b/src/test/headerFlavorBadgePlacement.test.tsx
@@ -15,7 +15,7 @@ describe('header flavor badge placement', () => {
 
     expect(screen.getByRole('heading', { name: 'タートルビデオ' })).toBeInTheDocument();
     expect(screen.queryByText('標準モード')).not.toBeInTheDocument();
-    expect(screen.queryByText('Apple Safari 検証モード')).not.toBeInTheDocument();
-    expect(screen.queryByText('Safari検証')).not.toBeInTheDocument();
+    expect(screen.queryByText('Apple Safari 動作モード')).not.toBeInTheDocument();
+    expect(screen.queryByText('Safari動作')).not.toBeInTheDocument();
   });
 });

--- a/src/test/modalHistoryStability.test.tsx
+++ b/src/test/modalHistoryStability.test.tsx
@@ -412,7 +412,7 @@ describe('modal history stability', () => {
 
     fireEvent.click(getByLabelText('保存・素材の説明'));
 
-    expect(getByText('Apple Safari 検証モード')).toBeTruthy();
+    expect(getByText('Apple Safari 動作モード')).toBeTruthy();
     expect(getByText(/通常タブ、ホーム画面追加、プライベートブラウズ/)).toBeTruthy();
   });
 });

--- a/src/test/previewSectionActionButtons.test.tsx
+++ b/src/test/previewSectionActionButtons.test.tsx
@@ -239,8 +239,8 @@ describe('PreviewSection action buttons', () => {
       supportsShowSaveFilePicker: false,
     });
 
-    expect(screen.getByText('Apple Safari 検証モード')).toBeInTheDocument();
-    expect(screen.getByText(/共有メニューまたは標準ダウンロード導線/)).toBeInTheDocument();
+    expect(screen.getByText('Apple Safari 動作モード')).toBeInTheDocument();
+    expect(screen.getByText(/共有メニュー、または通常のダウンロード手順/)).toBeInTheDocument();
   });
 
   it('export 完了後に processing=false なら download ボタンを表示する', () => {

--- a/src/test/sectionHelp.test.ts
+++ b/src/test/sectionHelp.test.ts
@@ -17,10 +17,10 @@ function getHelpDescription(
 }
 
 describe('sectionHelp support messaging', () => {
-  it('app help は iPhone Safari を非対応ではなく検証中として案内する', () => {
+  it('app help は iPhone Safari を非対応ではなく動作モードとして案内する', () => {
     const description = getHelpDescription('app', '動作確認機種');
 
-    expect(description).toContain('検証中');
+    expect(description).toContain('動作モード');
     expect(description).not.toContain('非対応');
   });
 
@@ -39,7 +39,7 @@ describe('sectionHelp support messaging', () => {
     expect(fallbackPreviewDescription).toContain('標準ダウンロード');
   });
 
-  it('apple-safari help は Safari 検証モード向けの案内を出す', () => {
+  it('apple-safari help は Safari 動作モード向けの案内を出す', () => {
     const appDescription = getHelpDescription('app', '動作確認機種', {
       appFlavor: 'apple-safari',
       supportsShowSaveFilePicker: false,
@@ -49,7 +49,7 @@ describe('sectionHelp support messaging', () => {
       supportsShowSaveFilePicker: false,
     });
 
-    expect(appDescription).toContain('安定動作優先の検証モード');
+    expect(appDescription).toContain('安定動作優先の動作モード');
     expect(previewDescription).toContain('共有メニュー');
   });
 });

--- a/src/test/versionMetadata.test.ts
+++ b/src/test/versionMetadata.test.ts
@@ -2,22 +2,26 @@ import { describe, expect, it } from 'vitest';
 import versionData from '../../version.json';
 
 describe('version metadata', () => {
-  it('v5.1.14 の現在バージョンと iOS Safari silent prewarm 完全廃止の変更概要を持つ', () => {
-    expect(versionData.version).toBe('5.1.14');
-    expect(versionData.history.previousVersion).toBe('5.1.13');
-    expect(versionData.history.summary).toContain('iOS Safari');
-    expect(versionData.history.summary).toContain('silent prewarm');
-    expect(versionData.history.highlights).toHaveLength(3);
+  it('v5.1.15 の現在バージョンと iOS Safari エクスポート完了 + UI 文言整備の変更概要を持つ', () => {
+    expect(versionData.version).toBe('5.1.15');
+    expect(versionData.history.previousVersion).toBe('5.1.14');
+    expect(versionData.history.summary).toContain('iPhone');
+    expect(versionData.history.summary).toContain('ダウンロードボタン');
+    expect(versionData.history.summary).toContain('動作モード');
+    expect(versionData.history.highlights).toHaveLength(4);
     expect(versionData.history.highlights).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          title: 'iOS Safari の silent prewarm を完全廃止 (映像が 1 フレーム目で固まる退行を解消)',
+          title: 'iOS Safari の export 100% 後にダウンロードボタンへ切り替わるよう修正',
         }),
         expect.objectContaining({
-          title: '境界での短い音声ギャップは stutter 許容前提として受け入れる',
+          title: 'Apple Safari の UI 文言を「検証モード」から「動作モード」へ変更',
         }),
         expect.objectContaining({
-          title: 'Android/PC プレビューには変更なし (apple-safari flavor 内でのみ完結)',
+          title: '「ダウンロード導線」を「ダウンロード手順」に修正 (日本語の自然化)',
+        }),
+        expect.objectContaining({
+          title: 'プレビューには変更なし (v5.1.14 で安定した動作を維持)',
         }),
       ])
     );

--- a/version.json
+++ b/version.json
@@ -1,20 +1,24 @@
 {
-  "version": "5.1.14",
+  "version": "5.1.15",
   "history": {
-    "previousVersion": "5.1.13",
-    "summary": "v5.1.13 で「BGM 無し動画でも WebAudio 経路を確立する」修正を入れたところ、副作用で「2 本目の動画が 1 フレーム目で固まって音だけ流れる」退行が再発しました。iOS Safari は createMediaElementSource() 接続済みの video を gain=0 で silent 再生すると視覚フレームの decode を停止する挙動が観測されたため、apple-safari preview から silent prewarm を完全に廃止し、active 化のタイミングで境界キックが play() を担う単一経路に統一しました。境界での短い音声ギャップは stutter 許容前提として受け入れます。",
+    "previousVersion": "5.1.14",
+    "summary": "iPhone/iPad Safari でエクスポート時、100% に到達してもダウンロードボタン (緑) に切り替わらず作成中ボタン (青) のままだった問題を修正しました。stopAll() が MediaRecorder の停止に requestData() を介さず stop() だけを直接呼んでいたため、iOS Safari 側で onstop が発火せず onRecordingStop コールバックが届かない退行になっていました。abort 経路と同じ「requestData() → 180ms 遅延 → stop()」手順に揃え、Android と同じく作成完了時に緑のダウンロードボタンが表示されるようにしました。あわせてアプリ内文言を「検証モード」から「動作モード」に、「ダウンロード導線」を「ダウンロード手順」に変更しています。プレビュー経路には一切手を入れていません。",
     "highlights": [
       {
-        "title": "iOS Safari の silent prewarm を完全廃止 (映像が 1 フレーム目で固まる退行を解消)",
-        "description": "iOS Safari は createMediaElementSource() 接続済みの video を gain=0 / native volume=0 で silent 再生すると、視覚フレームの decode を停止し「音は鳴るのに 1 フレーム目で映像が固まる」現象を引き起こすことが分かりました。apple-safari preview engine の startup prewarm 経路と render loop 経路の両方から silent play() を取り除き、active 化のタイミングで境界キックが fresh play() を呼ぶ単一経路にしました。"
+        "title": "iOS Safari の export 100% 後にダウンロードボタンへ切り替わるよう修正",
+        "description": "apple-safari preview engine の stopAll() が、export 終端で MediaRecorder.stop() を直接呼んでいたため、iOS Safari の MediaRecorder 仕様 (バッファフラッシュ前の stop は onstop を発火しないケースがある) で onstop が呼ばれず、setExportUrl が届かない退行になっていました。abort 経路と同じ「requestData() → 180ms 遅延 → stop()」手順に統一し、確実に onstop と onRecordingStop コールバックを発火させて、Android と同じく緑のダウンロードボタンへ切り替わるようにしました。"
       },
       {
-        "title": "境界での短い音声ギャップは stutter 許容前提として受け入れる",
-        "description": "silent prewarm を廃止することで、境界では新しい active video が paused 状態から play() するため、立ち上がり (~50ms) の短い音声ギャップが生じます。これは「動画と動画のつなぎ目で stutter を許容する」前提に合わせた割り切りです。視覚フレームの freeze 退行を防ぐことを優先しました。"
+        "title": "Apple Safari の UI 文言を「検証モード」から「動作モード」へ変更",
+        "description": "アプリ内バッジ、ヘルプ、保存/プレビューの案内文すべてを「Apple Safari 検証モード」から「Apple Safari 動作モード」に統一しました。実機検証で安定動作が確認できたフェーズに合わせた文言整備です。"
       },
       {
-        "title": "Android/PC プレビューには変更なし (apple-safari flavor 内でのみ完結)",
-        "description": "本修正は src/flavors/apple-safari/preview/previewPlatform.ts の shouldPrimeFutureInactiveVideoInPreview と src/flavors/apple-safari/preview/usePreviewEngine.ts の startEngine prewarm 経路のみを変更しており、Standard flavor (Android/PC) の挙動には変更を入れていません。standard 側はそもそも silent prewarm を実行しません (muteNativeMediaWhenAudioRouted=false)。"
+        "title": "「ダウンロード導線」を「ダウンロード手順」に修正 (日本語の自然化)",
+        "description": "「導線」という用語は UI 案内文として違和感があるため、「通常のダウンロード手順」「ダウンロード手順」のように分かりやすい表現に置き換えました。"
+      },
+      {
+        "title": "プレビューには変更なし (v5.1.14 で安定した動作を維持)",
+        "description": "今回の修正は apple-safari preview engine の stopAll() 内の MediaRecorder 停止手順と UI 文言のみで、プレビュー再生経路 (境界キック、WebAudio ルーティング、silent prewarm 廃止) には一切手を入れていません。v5.1.14 までで成立したプレビュー安定動作を維持します。安定動作の維持方針は Docs/2026-05-23_ios-safari-preview-stabilization-overview.md に明文化しました。"
       }
     ]
   }


### PR DESCRIPTION
## 概要

実機検証で iPhone / iPad Safari のプレビュー再生が安定動作 (v5.1.14) に到達した一方で、以下 3 つの課題が報告されました。本 PR でまとめて対応します。

| # | 課題 | 対応 |
|---|---|---|
| 1 | export 100% に達してもダウンロードボタン (緑) へ切り替わらず、作成中ボタン (青) のままになる | `stopAll()` の MediaRecorder 停止手順を iOS Safari 仕様 (`requestData()` → 180ms 遅延 → `stop()`) に修正 |
| 2 | 「Apple Safari 検証モード」の表現が安定動作確認後にそぐわない | アプリ内バッジ・ヘルプ・案内文を「動作モード」へ統一 |
| 3 | 「ダウンロード導線」という表現が日本語として違和感 | 「通常のダウンロード手順」「ダウンロード手順」へ変更 |

加えて、v5.1.11〜v5.1.14 で確立した preview 安定動作を維持するため、「触ってはいけない実装ポイント」をオーバービュー文書として保存しています。

## 1. export 完了時のダウンロードボタン切り替え (本丸)

### 根本原因

apple-safari preview engine の `stopAll()` は、export 終端で `recorderRef.current.stop()` を直接呼んでいました。

```ts
if (hasActiveRecorder) {
  recorderRef.current!.stop();  // ← 直接 stop
}
```

しかし iOS Safari の MediaRecorder は、**バッファフラッシュ前の `stop()` だと `onstop` イベントが発火しないケースがある**ことが実機テストから判明しました。`onstop` が発火しないと、`iosSafariMediaRecorder.ts` の以下のチェーンが届かなくなり、`useUIStore.exportUrl` がセットされず、ボタンは「作成中」のままになります。

```
recorder.onstop
  → state.setExportUrl(url)
  → callbacks.onRecordingStop(url, ext)
    → notifyRecordingStop
      → preview engine の onRecordingStop callback
        → useUIStore.setExportUrl(url)  ← ここまで届かない
        → useUIStore.setProcessing(false)
```

同じ問題回避が `iosSafariMediaRecorder.ts` の `onAbort` ハンドラには既に組み込まれており、**`requestData()` で先にバッファをフラッシュしてから 180ms 遅延で `stop()` を呼ぶ**手順になっていました。

### 修正

`stopAll()` の MediaRecorder 停止経路を abort 経路と同じパターンに統一しました。

```diff
 if (hasActiveRecorder) {
-  recorderRef.current!.stop();
+  const recorder = recorderRef.current!;
+  try {
+    recorder.requestData();  // フラッシュ
+  } catch {}
+  setTimeout(() => {
+    if (recorder.state !== 'inactive') {
+      try {
+        recorder.stop();
+      } catch {}
+    }
+  }, 180);
 }
```

これで `onstop` が確実に発火し、`useUIStore.exportUrl` が更新されて Android と同じくダウンロードボタン (緑) に切り替わります。

### preview への影響

ゼロです。修正は `stopAll()` の MediaRecorder 停止経路のみで、preview 経路 (境界キック / WebAudio ルーティング / silent prewarm 廃止) には一切手を入れていません。

## 2. UI 文言の整備

`src/app/appFlavorUi.ts` の以下を更新:

- ラベル: `Apple Safari 検証モード` → `Apple Safari 動作モード`
- コンパクトラベル: `Safari検証` → `Safari動作`
- 案内文: `標準ダウンロード導線` / `ダウンロード導線` → `通常のダウンロード手順` / `ダウンロード手順`
- サマリ: `安定動作優先の検証モード` → `安定動作優先の動作モード`

関連テスト 4 件 (`sectionHelp.test.ts`, `headerFlavorBadgePlacement.test.tsx`, `modalHistoryStability.test.tsx`, `previewSectionActionButtons.test.tsx`) もあわせて更新。

## 3. preview 安定動作の維持方針を明文化

`Docs/2026-05-23_ios-safari-preview-stabilization-overview.md` を新規追加し、v5.1.11〜v5.1.14 で積み上げた以下の 4 つの実装ポイントを「触ってはいけない」項目として記録しました。

1. **動画境界の play() キック** (v5.1.11 起点 / v5.1.12 で安定化): `currentTime` を触らない、prewarm 済みには介入しない
2. **BGM 無し単独動画でも WebAudio 経路を強制** (v5.1.13): `getPreviewAudioOutputMode` の単独動画分岐で `'webaudio'` を返す
3. **silent prewarm の完全廃止** (v5.1.14): `shouldPrimeFutureInactiveVideoInPreview` を全条件で `false` にし、startup の silent `play()` も削除
4. **active 化での play() 単一経路**: 境界キックが唯一の `play()` 起動源

## テスト

- 全 425 件 / 52 ファイルのテストが pass (新規回帰テスト 2 件を含む)
- 新規回帰テスト:
  - `stopAll` が active な MediaRecorder に対し `requestData()` → 180ms 遅延 → `stop()` を実行することを保証
  - `stopAll` が inactive な MediaRecorder には触れず `stopWebCodecsExport` にフォールバックすることを保証
- `npm run build` 通過

## Test plan

- [ ] iPhone Safari で動画 (BGM 無し) のエクスポート → 100% 到達後に緑のダウンロードボタンが表示されること
- [ ] iPhone Safari でダウンロードボタンを押下 → 動画が保存できること
- [ ] アプリ内バッジが「Apple Safari 動作モード」になっていること
- [ ] ヘルプ画面・保存案内文に「ダウンロード手順」が表示されていること (「導線」が無くなっていること)
- [ ] プレビュー再生 (v5.1.14 で確認済みの動作) に退行が無いこと
- [ ] Android プレビュー / export に退行なし

https://claude.ai/code/session_01Wo972ALf8zvAwMnfiYJEW6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wo972ALf8zvAwMnfiYJEW6)_