### PR TITLE
fix(export): iOS Safari の export 完了でダウンロードボタンへ切り替わらない退行を根本修正 (v5.1.16)

### DIFF
--- a/src/flavors/apple-safari/preview/usePreviewEngine.ts
+++ b/src/flavors/apple-safari/preview/usePreviewEngine.ts
@@ -129,6 +129,7 @@ interface UsePreviewEngineParams {
   resetInactiveVideos: () => void;
   startWebCodecsExport: UseExportReturn['startExport'];
   stopWebCodecsExport: UseExportReturn['stopExport'];
+  completeWebCodecsExport: UseExportReturn['completeExport'];
   startPreviewCacheExport?: UseExportReturn['startExport'];
   stopPreviewCacheExport?: UseExportReturn['stopExport'];
   completePreviewCacheExport?: UseExportReturn['completeExport'];
@@ -255,6 +256,7 @@ export function usePreviewEngine({
   resetInactiveVideos,
   startWebCodecsExport,
   stopWebCodecsExport,
+  completeWebCodecsExport,
   logInfo,
   logWarn,
   logDebug,
@@ -1540,22 +1542,22 @@ export function usePreviewEngine({
       });
     }
 
+    // stopAll は「ユーザー中断」「preview 自然終了」「export 完了 callback の
+    // 後片付け」など多用途で呼ばれる。export の自然完了経路は
+    // loop() の natural-end ハンドラ側で completeWebCodecsExport() / recorder.stop()
+    // を直接呼ぶように変更したため、ここでは「中断要求」と「すでに inactive な
+    // recorder のクリーンアップ」だけを担う。
     const hasActiveRecorder = !!(recorderRef.current && recorderRef.current.state !== 'inactive');
     if (hasActiveRecorder) {
-      // iOS Safari の MediaRecorder.stop() は、事前に requestData() を呼んで
-      // バッファをフラッシュしないと、最後のチャンクが届かず onstop が発火しない
-      // ケースが実機テストで観測された。その結果「100% まで進んでもダウンロード
-      // ボタンに切り替わらない」退行になる。abort 経路と同じ「requestData() →
-      // 短い遅延 → stop()」の手順で呼び、確実に onstop と onRecordingStop
-      // コールバックを発火させる。
+      // 中断要求側 (handleStop 等) から到達したケース。iOS Safari は
+      // recorder.stop() の前に requestData() でバッファをフラッシュしないと
+      // onstop が発火しないケースがあるため、abort 経路と同じ手順で停止する。
       const recorder = recorderRef.current!;
       try {
         recorder.requestData();
       } catch {
         /* ignore */
       }
-      // 180ms は abort 経路と同じ値。短すぎると iOS Safari でフラッシュが
-      // 間に合わないことがあるので、同じ間隔を採用する。
       setTimeout(() => {
         if (recorder.state !== 'inactive') {
           try {
@@ -1720,7 +1722,57 @@ export function usePreviewEngine({
           finalizeAtEnd();
           return;
         }
-        stopAll();
+
+        // === export 自然完了経路 ===
+        // ここで stopAll() を呼んでしまうと:
+        //  - MediaRecorder 経路: recorder.stop() の前に他要素が pause/cleanup
+        //    されて iOS Safari の onstop 不発に繋がる
+        //  - WebCodecs 経路: stopWebCodecsExport({reason:'user'}) で
+        //    exportCancelReasonRef='user' が立ち、notifyRecordingStop が
+        //    callback を suppress するため setExportUrl が呼ばれずに
+        //    「保存ファイルを作成中」のまま固まる
+        // 自然完了では「completeExport (WebCodecs)」または
+        // 「recorder.requestData()→stop()（MediaRecorder）」を直接呼んで、
+        // UI クリーンアップは onRecordingStop callback の側に任せる。
+        setCurrentTime(totalDurationRef.current);
+        currentTimeRef.current = totalDurationRef.current;
+        isPlayingRef.current = false;
+        if (reqIdRef.current) {
+          cancelAnimationFrame(reqIdRef.current);
+          reqIdRef.current = null;
+        }
+
+        const hasActiveRecorder = !!(recorderRef.current && recorderRef.current.state !== 'inactive');
+        if (hasActiveRecorder) {
+          // MediaRecorder 経路。iOS Safari は requestData() でバッファを
+          // フラッシュしてから 180ms 遅延で stop() する手順でないと onstop が
+          // 発火しないケースが観測されている (abort 経路と同じパターン)。
+          const recorder = recorderRef.current!;
+          logInfo('RENDER', 'iOS Safari: natural end -> MediaRecorder requestData+stop', {
+            recorderState: recorder.state,
+          });
+          try {
+            recorder.requestData();
+          } catch {
+            /* ignore */
+          }
+          setTimeout(() => {
+            if (recorder.state !== 'inactive') {
+              try {
+                recorder.stop();
+              } catch {
+                /* ignore */
+              }
+            }
+          }, 180);
+        } else {
+          // WebCodecs 経路。completeWebCodecsExport は
+          // exportCancelReasonRef='none' を維持したまま reader 群を cancel し、
+          // encoder finalize → notifyRecordingStop → onRecordingStop callback
+          // の自然完了チェーンに繋がる。
+          logInfo('RENDER', 'iOS Safari: natural end -> completeWebCodecsExport');
+          completeWebCodecsExport();
+        }
         return;
       }
       setCurrentTime(clampedElapsed);
@@ -1729,15 +1781,18 @@ export function usePreviewEngine({
       reqIdRef.current = requestAnimationFrame(() => loop(isExportMode, myLoopId));
     },
     [
+      completeWebCodecsExport,
       currentTimeRef,
       endFinalizedRef,
       isPlayingRef,
       logDebug,
+      logInfo,
       logWarn,
       loopIdRef,
       mediaElementsRef,
       mediaItemsRef,
       pause,
+      recorderRef,
       renderFrame,
       reqIdRef,
       setCurrentTime,

--- a/src/test/appleSafariPreviewEngineBoundary.test.tsx
+++ b/src/test/appleSafariPreviewEngineBoundary.test.tsx
@@ -256,6 +256,7 @@ describe('apple-safari preview engine boundary kick', () => {
         resetInactiveVideos: vi.fn(),
         startWebCodecsExport: vi.fn(),
         stopWebCodecsExport: vi.fn(),
+        completeWebCodecsExport: vi.fn(),
         logInfo,
         logWarn,
         logDebug: vi.fn(),
@@ -568,6 +569,7 @@ describe('apple-safari preview engine boundary kick', () => {
         resetInactiveVideos: vi.fn(),
         startWebCodecsExport: vi.fn(),
         stopWebCodecsExport,
+        completeWebCodecsExport: vi.fn(),
         logInfo,
         logWarn,
         logDebug: vi.fn(),
@@ -680,6 +682,7 @@ describe('apple-safari preview engine boundary kick', () => {
         resetInactiveVideos: vi.fn(),
         startWebCodecsExport: vi.fn(),
         stopWebCodecsExport,
+        completeWebCodecsExport: vi.fn(),
         logInfo: vi.fn(),
         logWarn: vi.fn(),
         logDebug: vi.fn(),
@@ -693,5 +696,255 @@ describe('apple-safari preview engine boundary kick', () => {
     expect(recorderMock.stop).not.toHaveBeenCalled();
     // 通常停止 (preview 終了等) は従来通り stopWebCodecsExport にフォールバック
     expect(stopWebCodecsExport).toHaveBeenCalledWith({ reason: 'user' });
+  });
+
+  it('export 自然終了で active な MediaRecorder には requestData()→180ms 遅延→stop() を呼び stopWebCodecsExport は呼ばない', () => {
+    // export 自然終了 (totalDuration 到達) では、stopAll() ではなく loop() の natural-end
+    // ハンドラが直接 requestData/stop を呼ぶ。これにより iOS Safari でも onstop が
+    // 確実に発火し、onRecordingStop callback で setExportUrl が走ってダウンロードボタン
+    // (緑) へ切り替わる。stopWebCodecsExport({reason:'user'}) は呼ばないため callback
+    // suppression が起きない。
+    const video1 = createVideoItem({ id: 'v1', duration: 6 });
+    const video1El = createMockVideoElement();
+    video1El.readyState = 4;
+    video1El.paused = false;
+    video1El.currentTime = 5.95;
+
+    const recorderMock = {
+      state: 'recording' as RecordingState,
+      requestData: vi.fn(),
+      stop: vi.fn(() => {
+        recorderMock.state = 'inactive';
+      }),
+    };
+    const recorderRef = createRef<MediaRecorder | null>(
+      recorderMock as unknown as MediaRecorder,
+    );
+
+    const canvasContext = createMockCanvasContext();
+    const logInfo = vi.fn();
+    const stopWebCodecsExport = vi.fn();
+    const completeWebCodecsExport = vi.fn();
+    const platformCapabilities = getAppleSafariPreviewPlatformCapabilities(createCapabilities());
+    const previewPlatformPolicy = appleSafariPreviewRuntime.getPreviewPlatformPolicy(
+      platformCapabilities,
+    );
+
+    vi.spyOn(Date, 'now').mockReturnValue(6500); // elapsed = 6.5s >= totalDuration=6s
+    vi.spyOn(globalThis, 'cancelAnimationFrame').mockImplementation(() => {});
+
+    const hook = renderHook(() =>
+      usePreviewEngine({
+        captions: [] as Caption[],
+        captionSettings: { enabled: false } as unknown as CaptionSettings,
+        mediaItemsRef: createRef([video1]),
+        bgmRef: createRef<AudioTrack | null>(null),
+        narrationsRef: createRef<NarrationClip[]>([]),
+        captionsRef: createRef<Caption[]>([]),
+        captionSettingsRef: createRef({ enabled: false } as unknown as CaptionSettings),
+        totalDurationRef: createRef(6),
+        currentTimeRef: createRef(5.95),
+        canvasRef: createRef({
+          getContext: vi.fn(() => canvasContext),
+        } as unknown as HTMLCanvasElement),
+        mediaElementsRef: createRef({
+          [video1.id]: video1El as unknown as HTMLVideoElement,
+        } as MediaElementsRef),
+        audioCtxRef: createRef(null),
+        sourceNodesRef: createRef({}),
+        gainNodesRef: createRef({}),
+        masterDestRef: createRef(null),
+        audioRoutingModeRef: createRef<'preview' | 'export'>('export'),
+        reqIdRef: createRef<number | null>(42),
+        startTimeRef: createRef(0),
+        audioResumeWaitFramesRef: createRef(0),
+        recorderRef,
+        loopIdRef: createRef(1),
+        isPlayingRef: createRef(true),
+        isSeekingRef: createRef(false),
+        isSeekPlaybackPreparingRef: createRef(false),
+        activeVideoIdRef: createRef<string | null>('v1'),
+        videoRecoveryAttemptsRef: createRef({}),
+        exportPlayFailedRef: createRef({}),
+        exportFallbackSeekAtRef: createRef({}),
+        seekingVideosRef: createRef(new Set<string>()),
+        pendingSeekRef: createRef<number | null>(null),
+        wasPlayingBeforeSeekRef: createRef(false),
+        pendingSeekTimeoutRef: createRef<ReturnType<typeof setTimeout> | null>(null),
+        previewPlaybackAttemptRef: createRef(1),
+        requestPreviewAudioRouteRefreshRef: createRef(() => { }),
+        primePreviewAudioOnlyTracksAtTimeRef: createRef(() => { }),
+        endFinalizedRef: createRef(false),
+        previewPlatformPolicy,
+        platformCapabilities,
+        setVideoDuration: vi.fn(),
+        setCurrentTime: vi.fn(),
+        setProcessing: vi.fn(),
+        setLoading: vi.fn(),
+        setExportPreparationStep: vi.fn(),
+        setExportUrl: vi.fn(),
+        setExportExt: vi.fn(),
+        clearExport: vi.fn(),
+        setError: vi.fn(),
+        play: vi.fn(),
+        pause: vi.fn(),
+        getAudioContext: vi.fn(),
+        cancelPendingPausedSeekWait: vi.fn(),
+        cancelPendingSeekPlaybackPrepare: vi.fn(),
+        detachGlobalSeekEndListeners: vi.fn(),
+        ensureAudioNodeForElement: vi.fn(() => false),
+        detachAudioNode: vi.fn(),
+        preparePreviewAudioNodesForTime: vi.fn(() => ({
+          activeVideoId: null,
+          audibleSourceCount: 0,
+          requiresWebAudio: false,
+        })),
+        preparePreviewAudioNodesForUpcomingVideos: vi.fn(),
+        primePreviewAudioOnlyTracksAtTime: vi.fn(),
+        resetInactiveVideos: vi.fn(),
+        startWebCodecsExport: vi.fn(),
+        stopWebCodecsExport,
+        completeWebCodecsExport,
+        logInfo,
+        logWarn: vi.fn(),
+        logDebug: vi.fn(),
+      }),
+    );
+
+    // loop を export モードで起動 (myLoopId=1, loopIdRef=1 で一致)
+    hook.result.current.loop(true, 1);
+
+    // requestData() は即時発火
+    expect(recorderMock.requestData).toHaveBeenCalledTimes(1);
+    // 180ms 未満では stop() は呼ばれない
+    expect(recorderMock.stop).not.toHaveBeenCalled();
+    // stopWebCodecsExport / completeWebCodecsExport はどちらも呼ばない
+    // (MediaRecorder 経路では recorder.stop() の onstop → onRecordingStop callback で UI を更新)
+    expect(stopWebCodecsExport).not.toHaveBeenCalled();
+    expect(completeWebCodecsExport).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(180);
+
+    // 180ms 後に recorder.stop() が呼ばれる
+    expect(recorderMock.stop).toHaveBeenCalledTimes(1);
+    // ログにも natural end → MediaRecorder の経路情報が残る
+    expect(
+      logInfo.mock.calls.some(([, msg]) => msg === 'iOS Safari: natural end -> MediaRecorder requestData+stop'),
+    ).toBe(true);
+  });
+
+  it('export 自然終了で recorder が無い (WebCodecs 経路) 場合は completeWebCodecsExport を呼び stopWebCodecsExport は呼ばない', () => {
+    // WebCodecs 経路 (recorder が null または inactive) の natural end では、
+    // stopWebCodecsExport({reason:'user'}) を呼ぶと exportCancelReasonRef='user' に
+    // なり notifyRecordingStop が callback を suppress するため、setExportUrl が
+    // 走らずダウンロードボタンへ切り替わらない退行になる。completeWebCodecsExport()
+    // を呼ぶことで cancelReason='none' のまま reader を cancel し、WebCodecs encoder
+    // を自然完了させる。
+    const video1 = createVideoItem({ id: 'v1', duration: 6 });
+    const video1El = createMockVideoElement();
+    video1El.readyState = 4;
+    video1El.paused = false;
+    video1El.currentTime = 5.95;
+
+    const canvasContext = createMockCanvasContext();
+    const logInfo = vi.fn();
+    const stopWebCodecsExport = vi.fn();
+    const completeWebCodecsExport = vi.fn();
+    const platformCapabilities = getAppleSafariPreviewPlatformCapabilities(createCapabilities());
+    const previewPlatformPolicy = appleSafariPreviewRuntime.getPreviewPlatformPolicy(
+      platformCapabilities,
+    );
+
+    vi.spyOn(Date, 'now').mockReturnValue(6500); // elapsed = 6.5s >= totalDuration=6s
+    vi.spyOn(globalThis, 'cancelAnimationFrame').mockImplementation(() => {});
+
+    const hook = renderHook(() =>
+      usePreviewEngine({
+        captions: [] as Caption[],
+        captionSettings: { enabled: false } as unknown as CaptionSettings,
+        mediaItemsRef: createRef([video1]),
+        bgmRef: createRef<AudioTrack | null>(null),
+        narrationsRef: createRef<NarrationClip[]>([]),
+        captionsRef: createRef<Caption[]>([]),
+        captionSettingsRef: createRef({ enabled: false } as unknown as CaptionSettings),
+        totalDurationRef: createRef(6),
+        currentTimeRef: createRef(5.95),
+        canvasRef: createRef({
+          getContext: vi.fn(() => canvasContext),
+        } as unknown as HTMLCanvasElement),
+        mediaElementsRef: createRef({
+          [video1.id]: video1El as unknown as HTMLVideoElement,
+        } as MediaElementsRef),
+        audioCtxRef: createRef(null),
+        sourceNodesRef: createRef({}),
+        gainNodesRef: createRef({}),
+        masterDestRef: createRef(null),
+        audioRoutingModeRef: createRef<'preview' | 'export'>('export'),
+        reqIdRef: createRef<number | null>(42),
+        startTimeRef: createRef(0),
+        audioResumeWaitFramesRef: createRef(0),
+        recorderRef: createRef<MediaRecorder | null>(null), // ← recorder なし (WebCodecs 経路)
+        loopIdRef: createRef(1),
+        isPlayingRef: createRef(true),
+        isSeekingRef: createRef(false),
+        isSeekPlaybackPreparingRef: createRef(false),
+        activeVideoIdRef: createRef<string | null>('v1'),
+        videoRecoveryAttemptsRef: createRef({}),
+        exportPlayFailedRef: createRef({}),
+        exportFallbackSeekAtRef: createRef({}),
+        seekingVideosRef: createRef(new Set<string>()),
+        pendingSeekRef: createRef<number | null>(null),
+        wasPlayingBeforeSeekRef: createRef(false),
+        pendingSeekTimeoutRef: createRef<ReturnType<typeof setTimeout> | null>(null),
+        previewPlaybackAttemptRef: createRef(1),
+        requestPreviewAudioRouteRefreshRef: createRef(() => { }),
+        primePreviewAudioOnlyTracksAtTimeRef: createRef(() => { }),
+        endFinalizedRef: createRef(false),
+        previewPlatformPolicy,
+        platformCapabilities,
+        setVideoDuration: vi.fn(),
+        setCurrentTime: vi.fn(),
+        setProcessing: vi.fn(),
+        setLoading: vi.fn(),
+        setExportPreparationStep: vi.fn(),
+        setExportUrl: vi.fn(),
+        setExportExt: vi.fn(),
+        clearExport: vi.fn(),
+        setError: vi.fn(),
+        play: vi.fn(),
+        pause: vi.fn(),
+        getAudioContext: vi.fn(),
+        cancelPendingPausedSeekWait: vi.fn(),
+        cancelPendingSeekPlaybackPrepare: vi.fn(),
+        detachGlobalSeekEndListeners: vi.fn(),
+        ensureAudioNodeForElement: vi.fn(() => false),
+        detachAudioNode: vi.fn(),
+        preparePreviewAudioNodesForTime: vi.fn(() => ({
+          activeVideoId: null,
+          audibleSourceCount: 0,
+          requiresWebAudio: false,
+        })),
+        preparePreviewAudioNodesForUpcomingVideos: vi.fn(),
+        primePreviewAudioOnlyTracksAtTime: vi.fn(),
+        resetInactiveVideos: vi.fn(),
+        startWebCodecsExport: vi.fn(),
+        stopWebCodecsExport,
+        completeWebCodecsExport,
+        logInfo,
+        logWarn: vi.fn(),
+        logDebug: vi.fn(),
+      }),
+    );
+
+    hook.result.current.loop(true, 1);
+
+    // completeWebCodecsExport() が呼ばれる (自然完了)
+    expect(completeWebCodecsExport).toHaveBeenCalledTimes(1);
+    // stopWebCodecsExport は呼ばれない (callback suppression 回避のため)
+    expect(stopWebCodecsExport).not.toHaveBeenCalled();
+    // ログにも natural end → WebCodecs の経路情報が残る
+    expect(
+      logInfo.mock.calls.some(([, msg]) => msg === 'iOS Safari: natural end -> completeWebCodecsExport'),
+    ).toBe(true);
   });
 });

--- a/src/test/versionMetadata.test.ts
+++ b/src/test/versionMetadata.test.ts
@@ -2,23 +2,23 @@ import { describe, expect, it } from 'vitest';
 import versionData from '../../version.json';
 
 describe('version metadata', () => {
-  it('v5.1.15 の現在バージョンと iOS Safari エクスポート完了 + UI 文言整備の変更概要を持つ', () => {
-    expect(versionData.version).toBe('5.1.15');
-    expect(versionData.history.previousVersion).toBe('5.1.14');
+  it('v5.1.16 の現在バージョンと iOS Safari export 自然完了経路修正の変更概要を持つ', () => {
+    expect(versionData.version).toBe('5.1.16');
+    expect(versionData.history.previousVersion).toBe('5.1.15');
     expect(versionData.history.summary).toContain('iPhone');
-    expect(versionData.history.summary).toContain('ダウンロードボタン');
-    expect(versionData.history.summary).toContain('動作モード');
+    expect(versionData.history.summary).toContain('completeWebCodecsExport');
+    expect(versionData.history.summary).toContain('onRecordingStop');
     expect(versionData.history.highlights).toHaveLength(4);
     expect(versionData.history.highlights).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          title: 'iOS Safari の export 100% 後にダウンロードボタンへ切り替わるよう修正',
+          title: 'export 自然完了経路を loop() に集約し WebCodecs/MediaRecorder ごとに正しい完了 API を呼ぶよう修正',
         }),
         expect.objectContaining({
-          title: 'Apple Safari の UI 文言を「検証モード」から「動作モード」へ変更',
+          title: 'apple-safari preview engine に completeWebCodecsExport パラメータを追加 (standard と同じ完了 API を受け取れるように)',
         }),
         expect.objectContaining({
-          title: '「ダウンロード導線」を「ダウンロード手順」に修正 (日本語の自然化)',
+          title: 'stopAll() は中断要求の責務に専念 (MediaRecorder 完了は loop() に委譲)',
         }),
         expect.objectContaining({
           title: 'プレビューには変更なし (v5.1.14 で安定した動作を維持)',

--- a/version.json
+++ b/version.json
@@ -1,24 +1,24 @@
 {
-  "version": "5.1.15",
+  "version": "5.1.16",
   "history": {
-    "previousVersion": "5.1.14",
-    "summary": "iPhone/iPad Safari でエクスポート時、100% に到達してもダウンロードボタン (緑) に切り替わらず作成中ボタン (青) のままだった問題を修正しました。stopAll() が MediaRecorder の停止に requestData() を介さず stop() だけを直接呼んでいたため、iOS Safari 側で onstop が発火せず onRecordingStop コールバックが届かない退行になっていました。abort 経路と同じ「requestData() → 180ms 遅延 → stop()」手順に揃え、Android と同じく作成完了時に緑のダウンロードボタンが表示されるようにしました。あわせてアプリ内文言を「検証モード」から「動作モード」に、「ダウンロード導線」を「ダウンロード手順」に変更しています。プレビュー経路には一切手を入れていません。",
+    "previousVersion": "5.1.15",
+    "summary": "iPhone/iPad Safari でエクスポートが 100% に到達してもダウンロードボタンへ切り替わらない問題を、根本原因まで遡って修正しました。apple-safari preview engine は loop() の natural-end ハンドラで stopAll() を呼んでいたため、WebCodecs 経路では stopWebCodecsExport({reason:'user'}) が exportCancelReasonRef='user' をセットして onRecordingStop callback を suppress し、MediaRecorder 経路では recorder.stop() の前に video/audio 要素が pause/cleanup されて iOS Safari の onstop 不発に繋がっていました。loop() の natural-end ハンドラを「stopAll() ではなく、recorder.requestData()→stop() (MediaRecorder) または completeWebCodecsExport() (WebCodecs)」を直接呼ぶ単一経路にすることで、確実に onRecordingStop callback まで届くようにしました。プレビューの動作には変更を入れていません。",
     "highlights": [
       {
-        "title": "iOS Safari の export 100% 後にダウンロードボタンへ切り替わるよう修正",
-        "description": "apple-safari preview engine の stopAll() が、export 終端で MediaRecorder.stop() を直接呼んでいたため、iOS Safari の MediaRecorder 仕様 (バッファフラッシュ前の stop は onstop を発火しないケースがある) で onstop が呼ばれず、setExportUrl が届かない退行になっていました。abort 経路と同じ「requestData() → 180ms 遅延 → stop()」手順に統一し、確実に onstop と onRecordingStop コールバックを発火させて、Android と同じく緑のダウンロードボタンへ切り替わるようにしました。"
+        "title": "export 自然完了経路を loop() に集約し WebCodecs/MediaRecorder ごとに正しい完了 API を呼ぶよう修正",
+        "description": "従来は export 完了で stopAll() を呼んでいましたが、これが WebCodecs 経路では stopWebCodecsExport({reason:'user'}) を発火し callback suppression を引き起こし、MediaRecorder 経路では video/audio の pause が iOS Safari の onstop 不発を引き起こしていました。loop() の natural-end で「recorder があれば requestData() + 180ms 遅延 + stop()」「recorder が無ければ completeWebCodecsExport()」を直接呼ぶ単一経路にし、onRecordingStop callback が必ず届くようにしました。"
       },
       {
-        "title": "Apple Safari の UI 文言を「検証モード」から「動作モード」へ変更",
-        "description": "アプリ内バッジ、ヘルプ、保存/プレビューの案内文すべてを「Apple Safari 検証モード」から「Apple Safari 動作モード」に統一しました。実機検証で安定動作が確認できたフェーズに合わせた文言整備です。"
+        "title": "apple-safari preview engine に completeWebCodecsExport パラメータを追加 (standard と同じ完了 API を受け取れるように)",
+        "description": "standard flavor は completeWebCodecsExport を受け取って自然完了で呼んでいましたが、apple-safari は受け取ってすらいませんでした。Param と destructure を追加して TurtleVideo.tsx 側から受け取れるようにし、WebCodecs 経路でも cancelReason='none' のまま自然完了できるようにしました。"
       },
       {
-        "title": "「ダウンロード導線」を「ダウンロード手順」に修正 (日本語の自然化)",
-        "description": "「導線」という用語は UI 案内文として違和感があるため、「通常のダウンロード手順」「ダウンロード手順」のように分かりやすい表現に置き換えました。"
+        "title": "stopAll() は中断要求の責務に専念 (MediaRecorder 完了は loop() に委譲)",
+        "description": "stopAll() の MediaRecorder 停止経路は handleStop など中断要求の経路から呼ばれた場合の保険として残しつつ、export 自然完了は loop() 側に移しました。これで「中断」と「自然完了」の経路が明確に分離されます。"
       },
       {
         "title": "プレビューには変更なし (v5.1.14 で安定した動作を維持)",
-        "description": "今回の修正は apple-safari preview engine の stopAll() 内の MediaRecorder 停止手順と UI 文言のみで、プレビュー再生経路 (境界キック、WebAudio ルーティング、silent prewarm 廃止) には一切手を入れていません。v5.1.14 までで成立したプレビュー安定動作を維持します。安定動作の維持方針は Docs/2026-05-23_ios-safari-preview-stabilization-overview.md に明文化しました。"
+        "description": "今回の修正は src/flavors/apple-safari/preview/usePreviewEngine.ts の loop()/stopAll() / param interface と回帰テストのみで、プレビュー再生経路 (境界キック、WebAudio ルーティング、silent prewarm 廃止) には一切手を入れていません。"
       }
     ]
   }


### PR DESCRIPTION
## 概要

実機テストで「iPhone Safari でエクスポートが 100% に到達してもダウンロードボタン (緑) へ切り替わらず、保存ファイルを作成中ボタン (青) のまま固まる」退行が再報告されました。v5.1.15 では `stopAll()` 内に `requestData() + 180ms 遅延 + stop()` を追加しましたが、それでは不十分でした。本 PR では根本原因まで遡って修正します。

## 根本原因

v5.1.15 までの apple-safari preview engine は、**`loop()` の natural-end ハンドラが `stopAll()` を呼んでいた**ことが本丸でした。`stopAll()` は「MediaRecorder 完了」と「中断要求」の責務を兼ねていたため、export 自然完了で 2 つの問題が発生していました。

### 問題 1: WebCodecs 経路 — callback が suppress される

`stopAll()` の else 分岐は `stopWebCodecsExport({reason:'user'})` を呼び、`exportCancelReasonRef='user'` をセットします。後続の `notifyRecordingStop` がこれを見て `onRecordingStop` callback を **suppress** します。結果 `setExportUrl` が呼ばれず、ボタンは「作成中」のまま固まります。

しかも、**`apple-safari` preview engine は `completeWebCodecsExport` を param として受け取ってすらいませんでした**。standard flavor は受け取って自然完了で呼んでいたのに、apple-safari にはその経路自体が存在しなかったのです。

```
apple-safari (旧)                       standard (参考)
loop natural-end                        loop natural-end
  └ stopAll()                              └ completeWebCodecsExport()
      └ stopWebCodecsExport({user})            └ cancelReason='none' 維持
          └ cancelReason='user'                    └ encoder finalize
              └ callback SUPPRESSED ✗                  └ callback 発火 ✓
```

### 問題 2: MediaRecorder 経路 — pause/cleanup が先に走る

`stopAll()` は `recorder.stop()` の前に video/audio 要素を pause / cleanup します。iOS Safari は要素 pause で audio 経路が断たれた後の `recorder.stop()` で `onstop` が発火しないケースが残ります。v5.1.15 で `requestData()` を追加しましたが、**`stopAll()` 内の他処理 (pause / cleanup) との順序が逆転していた**ため不十分でした。

## 修正内容

apple-safari preview engine を「自然完了」と「中断」で経路を分離しました。

### 1. `UsePreviewEngineParams` に `completeWebCodecsExport` を追加

```diff
 resetInactiveVideos: () => void;
 startWebCodecsExport: UseExportReturn['startExport'];
 stopWebCodecsExport: UseExportReturn['stopExport'];
+completeWebCodecsExport: UseExportReturn['completeExport'];
 startPreviewCacheExport?: UseExportReturn['startExport'];
```

TurtleVideo.tsx は既に渡していたが apple-safari 側が受け取っていなかったため、追加するだけで配線が完成します。

### 2. `loop()` の natural-end ハンドラを単一経路に集約

```diff
 if (clampedElapsed >= totalDurationRef.current) {
   if (!isExportMode) {
     // preview 自然終了 (既存)
     return;
   }
-  stopAll();
+  // export 自然完了経路
+  setCurrentTime(totalDurationRef.current);
+  isPlayingRef.current = false;
+  cancelAnimationFrame(reqIdRef.current);
+
+  if (hasActiveRecorder) {
+    // MediaRecorder: requestData() → 180ms 遅延 → stop()
+    recorder.requestData();
+    setTimeout(() => recorder.stop(), 180);
+  } else {
+    // WebCodecs: completeWebCodecsExport() で natural completion
+    completeWebCodecsExport();
+  }
   return;
 }
```

これにより:
- **MediaRecorder 経路**: video/audio が pause される前に recorder のフラッシュ + stop() が走り、iOS Safari の `onstop` が確実に発火する
- **WebCodecs 経路**: `completeWebCodecsExport()` が `exportCancelReasonRef='none'` を維持したまま encoder finalize → `notifyRecordingStop` → `onRecordingStop` callback の自然完了チェーンに繋がる

### 3. `stopAll()` は中断要求の責務に専念

`stopAll()` の MediaRecorder 停止経路 (v5.1.15 で追加した `requestData + delay + stop`) は `handleStop` など中断要求から到達した場合の保険として残しつつ、export 自然完了は `loop()` 側に移しました。

## 影響範囲

- **変更対象**: `src/flavors/apple-safari/preview/usePreviewEngine.ts` のみ
- Standard flavor (Android/PC) / プレビュー再生経路 (境界キック / WebAudio ルーティング / silent prewarm 廃止) には変更なし
- v5.1.14 で確認済みの preview 安定動作はそのまま維持

## テスト

- 全 **427 件** / 52 ファイルのテストが pass
- 新規回帰テスト 2 件:
  - export 自然終了で active な MediaRecorder には `requestData()→180ms→stop()` を呼び、`stopWebCodecsExport` は呼ばないことを保証
  - export 自然終了で recorder が無い (WebCodecs 経路) ときは `completeWebCodecsExport()` を呼び、`stopWebCodecsExport` は呼ばないことを保証
- `npm run build` 通過

## Test plan

- [ ] iPhone Safari で 6 秒の動画 (BGM 無し) のエクスポート → 100% 到達後にダウンロードボタン (緑) が表示されること
- [ ] iPhone Safari で複合動画 (動画 + 画像 + 動画 など) のエクスポート → 同じくダウンロードボタン (緑) が表示されること
- [ ] iPhone Safari で BGM ありエクスポート → ダウンロードボタンが表示されること
- [ ] エクスポート途中で停止ボタンを押す (中断要求) → 作成中ボタンが消えること (stopAll 経路の回帰確認)
- [ ] Android プレビュー / export に退行なし
- [ ] プレビュー再生 (v5.1.14 で確認済みの動作) に退行なし

https://claude.ai/code/session_01Wo972ALf8zvAwMnfiYJEW6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wo972ALf8zvAwMnfiYJEW6)_