### PR TITLE
fix(export): iOS Safari MediaRecorder の onstop 不発を watchdog で根本救済 (v5.1.17)

### DIFF
--- a/src/flavors/apple-safari/export/iosSafariMediaRecorder.ts
+++ b/src/flavors/apple-safari/export/iosSafariMediaRecorder.ts
@@ -186,17 +186,75 @@ export async function runIosSafariMediaRecorderStrategy(
     let recorder: MediaRecorder | null = null;
     let pausedByVisibility = false;
     let visibilityListenersAttached = false;
+    let stopWatchdogTimer: ReturnType<typeof setTimeout> | null = null;
+    let onstopFired = false;
 
     const finishResolve = () => {
       if (settled) return;
       settled = true;
+      if (stopWatchdogTimer !== null) {
+        clearTimeout(stopWatchdogTimer);
+        stopWatchdogTimer = null;
+      }
       resolve();
     };
 
-    const finishReject = (error: Error) => {
-      if (settled) return;
-      settled = true;
-      reject(error);
+    // 以前は finishReject 経由で Promise を reject していたが、await 側で
+    // catch されておらず「保存ファイルを作成中」のまま UI が固まる退行の原因
+    // になっていたため、エラー経路は callbacks.onRecordingError + finishResolve
+    // に統一した。Promise reject は使わない。reject 参照は今後の defensive 用に
+    // 残すが、現状の経路では呼び出さない。
+    void reject;
+
+    /**
+     * iOS Safari の MediaRecorder は recorder.stop() を呼んでも onstop が
+     * 発火しない / 大きく遅延するケースが実機で観測される。stop() を呼んでから
+     * STOP_WATCHDOG_TIMEOUT_MS 経っても onstop が来なかった場合は、それまでに
+     * 累積した chunks から手動で blob を作って onRecordingStop を発火させる。
+     * 「保存ファイルを作成中」のまま固まってダウンロードボタンに切り替わらない
+     * 退行を防ぐためのフェイルセーフ。
+     */
+    const STOP_WATCHDOG_TIMEOUT_MS = 8000;
+    const armStopWatchdog = () => {
+      if (stopWatchdogTimer !== null) return;
+      stopWatchdogTimer = setTimeout(() => {
+        stopWatchdogTimer = null;
+        if (onstopFired || settled) return;
+        log.warn('RENDER', 'iOS Safari: MediaRecorder onstop did not fire in time, force-completing', {
+          exportSessionId,
+          probe,
+          chunks: chunks.length,
+          recorderState: recorder?.state ?? 'unknown',
+        });
+        // 手動で onstop と同じ後処理を実行する
+        try {
+          cleanup();
+        } catch {
+          /* ignore */
+        }
+        refs.recorderRef.current = null;
+        if (chunks.length === 0) {
+          // chunks が空なら成功失敗の判別不能。エラーコールバックで UI を救出する。
+          callbacks.onRecordingError?.(
+            'iOS Safari の動画書き出しが完了通知を返しませんでした。少し時間を置いてからやり直してください。',
+          );
+          finishResolve();
+          return;
+        }
+        const blob = new Blob(chunks, { type: profile.mimeType || 'video/mp4' });
+        const url = URL.createObjectURL(blob);
+        state.setExportUrl(url);
+        state.setExportExt(profile.extension);
+        log.info('RENDER', 'iOS Safari: MediaRecorder export completed (watchdog path)', {
+          exportSessionId,
+          probe,
+          chunks: chunks.length,
+          blobSizeBytes: blob.size,
+          extension: profile.extension,
+        });
+        callbacks.onRecordingStop(url, profile.extension);
+        finishResolve();
+      }, STOP_WATCHDOG_TIMEOUT_MS);
     };
 
     const handleRecorderVisibilityChange = () => {
@@ -292,6 +350,8 @@ export async function runIosSafariMediaRecorderStrategy(
           if (recorder && recorder.state !== 'inactive') {
             try {
               recorder.stop();
+              // iOS Safari の onstop 不発に備え、stop() 呼び出し後に watchdog を起動
+              armStopWatchdog();
             } catch {
               // ignore
             }
@@ -331,16 +391,44 @@ export async function runIosSafariMediaRecorderStrategy(
     };
 
     recorder.onerror = () => {
+      // recorder.onerror も finishReject にしていたが、await 側に catch が無く
+      // 「保存ファイルを作成中」固まりの原因になっていた。onRecordingError で
+      // UI を救出してから finishResolve する。
+      log.warn('RENDER', 'iOS Safari: MediaRecorder error event', {
+        exportSessionId,
+        probe,
+        recorderState: recorder?.state ?? 'unknown',
+      });
+      if (stopWatchdogTimer !== null) {
+        clearTimeout(stopWatchdogTimer);
+        stopWatchdogTimer = null;
+      }
       cleanup();
-      finishReject(new Error('MediaRecorder recording failed'));
+      callbacks.onRecordingError?.('iOS Safari の動画書き出し中にエラーが発生しました。');
+      finishResolve();
     };
 
     recorder.onstop = () => {
+      onstopFired = true;
+      if (stopWatchdogTimer !== null) {
+        clearTimeout(stopWatchdogTimer);
+        stopWatchdogTimer = null;
+      }
       cleanup();
       refs.recorderRef.current = null;
 
       if (chunks.length === 0) {
-        finishReject(new Error('MediaRecorder produced no output data'));
+        // 以前は finishReject していたが、await 側で catch されないため
+        // 「保存ファイルを作成中」のまま UI が固まる退行になっていた。
+        // onRecordingError で UI を救出してから finishResolve でクリーンに抜ける。
+        log.warn('RENDER', 'iOS Safari: MediaRecorder produced no output data (onstop chunks=0)', {
+          exportSessionId,
+          probe,
+        });
+        callbacks.onRecordingError?.(
+          'iOS Safari の動画書き出しでデータが取得できませんでした。少し時間を置いてからやり直してください。',
+        );
+        finishResolve();
         return;
       }
 
@@ -371,6 +459,20 @@ export async function runIosSafariMediaRecorderStrategy(
       }
       preRenderedAudio?.startPlayback();
       startedSuccessfully = true;
+      // iOS Safari は recorder.stop() が外部 (preview engine の natural-end ハンドラ等)
+      // から呼ばれて state が 'inactive' になっても onstop が発火しないケースが
+      // 観測されるため、state を監視して inactive 検出時にウォッチドッグを起動する。
+      // onAbort 経由でも armStopWatchdog が呼ばれるが、これがフェイルセーフになる。
+      const stateMonitorTimer = setInterval(() => {
+        if (settled || onstopFired) {
+          clearInterval(stateMonitorTimer);
+          return;
+        }
+        if (recorder && recorder.state === 'inactive') {
+          clearInterval(stateMonitorTimer);
+          armStopWatchdog();
+        }
+      }, 200);
       log.info('RENDER', 'iOS Safari: MediaRecorder export ready', {
         exportSessionId,
         probe,

--- a/src/flavors/apple-safari/preview/usePreviewEngine.ts
+++ b/src/flavors/apple-safari/preview/usePreviewEngine.ts
@@ -2284,7 +2284,14 @@ export function usePreviewEngine({
       startTimeRef.current = Date.now() - fromTime * 1000;
 
       if (isExportMode && canvasRef.current && masterDestRef.current) {
-        startWebCodecsExport(
+        // startWebCodecsExport は async (Promise<void>) を返すため、内部で発生した
+        // 例外 (MediaRecorder 戦略の reject 等) を握りつぶさないように .catch() で
+        // 確実に UI を中断状態へ戻す。catch が無いと「保存ファイルを作成中」のまま
+        // 固まる退行の原因になる。
+        // startWebCodecsExport は内部で async として実装されているため、戻り値は
+        // 実体上 Promise になる。型定義上は void なので一旦 unknown を経由して
+        // PromiseLike として扱い、reject が握りつぶされて UI が固まる退行を防ぐ。
+        const exportResult = startWebCodecsExport(
           canvasRef,
           masterDestRef,
           (url, ext) => {
@@ -2314,7 +2321,19 @@ export function usePreviewEngine({
               loop(isExportMode, myLoopId);
             },
           },
-        );
+        ) as unknown as Promise<void> | void;
+        if (exportResult && typeof (exportResult as { catch?: unknown }).catch === 'function') {
+          (exportResult as Promise<void>).catch((err: unknown) => {
+            logWarn('RENDER', 'iOS Safari: startWebCodecsExport rejected; recovering UI state', {
+              error: err instanceof Error ? err.message : String(err),
+            });
+            setProcessing(false);
+            setExportPreparationStep(null);
+            pause();
+            stopAll();
+            setError('動画ファイルの作成に失敗しました。少し時間を置いてからやり直してください。');
+          });
+        }
       } else {
         loop(isExportMode, myLoopId);
       }

--- a/src/test/iosSafariMediaRecorder.test.ts
+++ b/src/test/iosSafariMediaRecorder.test.ts
@@ -364,4 +364,217 @@ describe('runIosSafariMediaRecorderStrategy', () => {
     expect(audioContext.createOscillator).not.toHaveBeenCalled();
     expect(createObjectUrlSpy).toHaveBeenCalled();
   });
+
+  it('iOS Safari で onstop が発火せず state=inactive のままでも watchdog が chunks から blob を作って完了させる', async () => {
+    // 実機 iOS Safari で観測される「recorder.stop() を呼んでも onstop が発火しない」
+    // ケースの再現テスト。stop() は呼ばれたが onstop イベントが届かない状態で、
+    // watchdog (8 秒タイムアウト) が chunks から blob を組み立てて onRecordingStop
+    // を発火させ、UI が「保存ファイルを作成中」のまま固まらないことを保証する。
+    const videoTrack: FakeTrack = {
+      kind: 'video',
+      readyState: 'live',
+      stop: vi.fn(),
+      requestFrame: vi.fn(),
+    };
+    const recorderAudioTrack: FakeTrack = {
+      kind: 'audio',
+      readyState: 'live',
+      stop: vi.fn(),
+    };
+    const sourceAudioTrack: FakeTrack = {
+      kind: 'audio',
+      readyState: 'live',
+      stop: vi.fn(),
+      clone: () => recorderAudioTrack,
+    };
+    const { canvas } = createCanvasDouble(videoTrack);
+    const callbacks = createCallbacks();
+    const state = createStateSetters();
+    const recorderRef = { current: null as MediaRecorder | null };
+    const onAudioPreRenderComplete = vi.fn();
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob:ios-watchdog');
+
+    class StuckMediaRecorder {
+      state: RecordingState = 'inactive';
+      ondataavailable: ((event: BlobEvent) => void) | null = null;
+      onerror: (() => void) | null = null;
+      onstop: (() => void) | null = null;
+      readonly start = vi.fn((timeslice?: number) => {
+        this.state = 'recording';
+        this.timeslice = timeslice;
+        // 250ms ごとに chunks を投入する (timeslice 動作の擬似再現)
+        setTimeout(() => {
+          this.ondataavailable?.({ data: new Blob(['frame1']) } as BlobEvent);
+        }, 250);
+      });
+      readonly pause = vi.fn(() => {
+        this.state = 'paused';
+      });
+      readonly resume = vi.fn(() => {
+        this.state = 'recording';
+      });
+      readonly requestData = vi.fn(() => {
+        // requestData() でも chunks に追加するが onstop は発火しない
+        this.ondataavailable?.({ data: new Blob(['final']) } as BlobEvent);
+      });
+      // iOS Safari 退行の再現: stop() を呼んでも state は inactive になるが
+      // onstop は発火しない。
+      readonly stop = vi.fn(() => {
+        this.state = 'inactive';
+        // onstop?.() は意図的に呼ばない
+      });
+      timeslice?: number;
+
+      constructor(
+        readonly stream: MediaStream,
+        readonly options?: MediaRecorderOptions,
+      ) {}
+    }
+
+    vi.stubGlobal('MediaRecorder', StuckMediaRecorder as unknown as typeof MediaRecorder);
+
+    const promise = runIosSafariMediaRecorderStrategy({
+      canvas,
+      masterDest: {
+        stream: new FakeMediaStream([sourceAudioTrack]),
+      } as unknown as MediaStreamAudioDestinationNode,
+      audioContext: createAudioContextDouble(),
+      signal: new AbortController().signal,
+      audioSources: {
+        mediaItems: [],
+        bgm: null,
+        narrations: [],
+        totalDuration: 1,
+        onAudioPreRenderComplete,
+      },
+      callbacks,
+      state,
+      refs: {
+        recorderRef,
+      },
+      exportConfig: {
+        fps: 30,
+        videoBitrate: 1_000_000,
+      },
+      supportedMediaRecorderProfile: {
+        mimeType: 'video/mp4',
+        extension: 'mp4',
+      },
+    });
+
+    // recorder.start() の setTimeout(250) で chunks を入れる
+    await vi.advanceTimersByTimeAsync(250);
+    // signal は abort されないので、natural-end ハンドラ相当: 外部から stop() を呼ぶ
+    const recorder = recorderRef.current as unknown as StuckMediaRecorder;
+    recorder.requestData(); // chunks 追加
+    recorder.stop(); // state=inactive にする (onstop は発火しない)
+
+    // state monitor (200ms interval) が inactive を検出して watchdog を arm
+    await vi.advanceTimersByTimeAsync(200);
+    // watchdog timeout (8000ms) を経過させる
+    await vi.advanceTimersByTimeAsync(8000);
+
+    await promise;
+
+    // watchdog が onRecordingStop を発火させた
+    expect(state.setExportUrl).toHaveBeenCalledWith('blob:ios-watchdog');
+    expect(state.setExportExt).toHaveBeenCalledWith('mp4');
+    expect(callbacks.onRecordingStop).toHaveBeenCalledWith('blob:ios-watchdog', 'mp4');
+    expect(callbacks.onRecordingError).not.toHaveBeenCalled();
+  });
+
+  it('iOS Safari で onstop が発火せず chunks も空のままなら watchdog が onRecordingError を発火して UI を救出する', async () => {
+    // 最悪パターン: stop() を呼んでも onstop が発火せず chunks も空のままだと、
+    // 何も発火しないと UI は「保存ファイルを作成中」のまま固まる。watchdog が
+    // onRecordingError を発火して UI をエラー状態に戻すことを保証する。
+    const videoTrack: FakeTrack = {
+      kind: 'video',
+      readyState: 'live',
+      stop: vi.fn(),
+      requestFrame: vi.fn(),
+    };
+    const recorderAudioTrack: FakeTrack = {
+      kind: 'audio',
+      readyState: 'live',
+      stop: vi.fn(),
+    };
+    const sourceAudioTrack: FakeTrack = {
+      kind: 'audio',
+      readyState: 'live',
+      stop: vi.fn(),
+      clone: () => recorderAudioTrack,
+    };
+    const { canvas } = createCanvasDouble(videoTrack);
+    const callbacks = createCallbacks();
+    const state = createStateSetters();
+    const recorderRef = { current: null as MediaRecorder | null };
+
+    class EmptyStuckMediaRecorder {
+      state: RecordingState = 'inactive';
+      ondataavailable: ((event: BlobEvent) => void) | null = null;
+      onerror: (() => void) | null = null;
+      onstop: (() => void) | null = null;
+      readonly start = vi.fn(() => {
+        this.state = 'recording';
+      });
+      readonly pause = vi.fn();
+      readonly resume = vi.fn();
+      readonly requestData = vi.fn(); // chunks には何も入れない
+      readonly stop = vi.fn(() => {
+        this.state = 'inactive';
+        // onstop?.() は呼ばない
+      });
+      timeslice?: number;
+
+      constructor(
+        readonly stream: MediaStream,
+        readonly options?: MediaRecorderOptions,
+      ) {}
+    }
+
+    vi.stubGlobal('MediaRecorder', EmptyStuckMediaRecorder as unknown as typeof MediaRecorder);
+
+    const promise = runIosSafariMediaRecorderStrategy({
+      canvas,
+      masterDest: {
+        stream: new FakeMediaStream([sourceAudioTrack]),
+      } as unknown as MediaStreamAudioDestinationNode,
+      audioContext: createAudioContextDouble(),
+      signal: new AbortController().signal,
+      audioSources: {
+        mediaItems: [],
+        bgm: null,
+        narrations: [],
+        totalDuration: 1,
+        onAudioPreRenderComplete: vi.fn(),
+      },
+      callbacks,
+      state,
+      refs: {
+        recorderRef,
+      },
+      exportConfig: {
+        fps: 30,
+        videoBitrate: 1_000_000,
+      },
+      supportedMediaRecorderProfile: {
+        mimeType: 'video/mp4',
+        extension: 'mp4',
+      },
+    });
+
+    const recorder = recorderRef.current as unknown as EmptyStuckMediaRecorder;
+    recorder.stop();
+
+    await vi.advanceTimersByTimeAsync(200);
+    await vi.advanceTimersByTimeAsync(8000);
+
+    await promise;
+
+    // chunks 空 → onRecordingStop は発火しない、onRecordingError が発火する
+    expect(callbacks.onRecordingStop).not.toHaveBeenCalled();
+    expect(callbacks.onRecordingError).toHaveBeenCalledWith(
+      expect.stringContaining('iOS Safari'),
+    );
+  });
 });

--- a/src/test/versionMetadata.test.ts
+++ b/src/test/versionMetadata.test.ts
@@ -2,23 +2,23 @@ import { describe, expect, it } from 'vitest';
 import versionData from '../../version.json';
 
 describe('version metadata', () => {
-  it('v5.1.16 の現在バージョンと iOS Safari export 自然完了経路修正の変更概要を持つ', () => {
-    expect(versionData.version).toBe('5.1.16');
-    expect(versionData.history.previousVersion).toBe('5.1.15');
-    expect(versionData.history.summary).toContain('iPhone');
-    expect(versionData.history.summary).toContain('completeWebCodecsExport');
-    expect(versionData.history.summary).toContain('onRecordingStop');
+  it('v5.1.17 の現在バージョンと iOS Safari MediaRecorder onstop watchdog の変更概要を持つ', () => {
+    expect(versionData.version).toBe('5.1.17');
+    expect(versionData.history.previousVersion).toBe('5.1.16');
+    expect(versionData.history.summary).toContain('iPhone Safari');
+    expect(versionData.history.summary).toContain('watchdog');
+    expect(versionData.history.summary).toContain('onstop');
     expect(versionData.history.highlights).toHaveLength(4);
     expect(versionData.history.highlights).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          title: 'export 自然完了経路を loop() に集約し WebCodecs/MediaRecorder ごとに正しい完了 API を呼ぶよう修正',
+          title: 'iOS Safari MediaRecorder の onstop 不発に対する watchdog を追加 (UI が「保存ファイルを作成中」のまま固まる退行を救出)',
         }),
         expect.objectContaining({
-          title: 'apple-safari preview engine に completeWebCodecsExport パラメータを追加 (standard と同じ完了 API を受け取れるように)',
+          title: 'MediaRecorder 戦略のエラー経路を Promise reject から callbacks.onRecordingError へ統一',
         }),
         expect.objectContaining({
-          title: 'stopAll() は中断要求の責務に専念 (MediaRecorder 完了は loop() に委譲)',
+          title: 'apple-safari startEngine の startWebCodecsExport 呼び出しに .catch() を追加',
         }),
         expect.objectContaining({
           title: 'プレビューには変更なし (v5.1.14 で安定した動作を維持)',

--- a/version.json
+++ b/version.json
@@ -1,24 +1,24 @@
 {
-  "version": "5.1.16",
+  "version": "5.1.17",
   "history": {
-    "previousVersion": "5.1.15",
-    "summary": "iPhone/iPad Safari でエクスポートが 100% に到達してもダウンロードボタンへ切り替わらない問題を、根本原因まで遡って修正しました。apple-safari preview engine は loop() の natural-end ハンドラで stopAll() を呼んでいたため、WebCodecs 経路では stopWebCodecsExport({reason:'user'}) が exportCancelReasonRef='user' をセットして onRecordingStop callback を suppress し、MediaRecorder 経路では recorder.stop() の前に video/audio 要素が pause/cleanup されて iOS Safari の onstop 不発に繋がっていました。loop() の natural-end ハンドラを「stopAll() ではなく、recorder.requestData()→stop() (MediaRecorder) または completeWebCodecsExport() (WebCodecs)」を直接呼ぶ単一経路にすることで、確実に onRecordingStop callback まで届くようにしました。プレビューの動作には変更を入れていません。",
+    "previousVersion": "5.1.16",
+    "summary": "iPhone Safari でエクスポート完了後にダウンロードボタン (緑) へ切り替わらない問題を、iOS Safari MediaRecorder の onstop 不発に対する watchdog で根本的に救済しました。実機テストで recorder.stop() を呼んでも state は inactive になるが onstop イベントが発火しないケースが観測されたため、iosSafariMediaRecorder.ts に「8 秒タイムアウト + state=inactive 検出 + chunks からの手動 blob 構築」watchdog を追加しました。さらに recorder.onstop / recorder.onerror / chunks=0 のエラー経路を Promise reject から callbacks.onRecordingError + finishResolve へ統一し、await 側で握りつぶされていたエラーで UI が固まる退行も解消しました。",
     "highlights": [
       {
-        "title": "export 自然完了経路を loop() に集約し WebCodecs/MediaRecorder ごとに正しい完了 API を呼ぶよう修正",
-        "description": "従来は export 完了で stopAll() を呼んでいましたが、これが WebCodecs 経路では stopWebCodecsExport({reason:'user'}) を発火し callback suppression を引き起こし、MediaRecorder 経路では video/audio の pause が iOS Safari の onstop 不発を引き起こしていました。loop() の natural-end で「recorder があれば requestData() + 180ms 遅延 + stop()」「recorder が無ければ completeWebCodecsExport()」を直接呼ぶ単一経路にし、onRecordingStop callback が必ず届くようにしました。"
+        "title": "iOS Safari MediaRecorder の onstop 不発に対する watchdog を追加 (UI が「保存ファイルを作成中」のまま固まる退行を救出)",
+        "description": "iOS Safari は recorder.stop() を呼んでも onstop イベントが発火しないことが実機で観測されました。8 秒タイムアウトの watchdog と、recorder.state が inactive に遷移したことを 200ms 間隔の state monitor で検出するセーフティネットを追加し、watchdog が chunks から手動で blob を構築して onRecordingStop callback を発火させることで、UI を「保存ファイルを作成中」のまま固まらせない手当をしました。chunks が空のままでも onRecordingError を発火させて UI をエラー状態へ復帰させます。"
       },
       {
-        "title": "apple-safari preview engine に completeWebCodecsExport パラメータを追加 (standard と同じ完了 API を受け取れるように)",
-        "description": "standard flavor は completeWebCodecsExport を受け取って自然完了で呼んでいましたが、apple-safari は受け取ってすらいませんでした。Param と destructure を追加して TurtleVideo.tsx 側から受け取れるようにし、WebCodecs 経路でも cancelReason='none' のまま自然完了できるようにしました。"
+        "title": "MediaRecorder 戦略のエラー経路を Promise reject から callbacks.onRecordingError へ統一",
+        "description": "recorder.onerror や chunks=0 で従来は Promise reject を返していたため、await 側で握りつぶされて UI が固まる退行が起きていました。これらを callbacks.onRecordingError(message) + finishResolve() に統一し、エラー時も必ず UI が「作成中」から復帰するようにしました。"
       },
       {
-        "title": "stopAll() は中断要求の責務に専念 (MediaRecorder 完了は loop() に委譲)",
-        "description": "stopAll() の MediaRecorder 停止経路は handleStop など中断要求の経路から呼ばれた場合の保険として残しつつ、export 自然完了は loop() 側に移しました。これで「中断」と「自然完了」の経路が明確に分離されます。"
+        "title": "apple-safari startEngine の startWebCodecsExport 呼び出しに .catch() を追加",
+        "description": "万一 startWebCodecsExport が unhandled rejection を起こしても UI を中断状態へ戻せるよう、preview engine 側でも防御的に .catch() を仕掛けました。多層防御により「保存ファイルを作成中」固まりを 3 段階で救出する構造になっています。"
       },
       {
         "title": "プレビューには変更なし (v5.1.14 で安定した動作を維持)",
-        "description": "今回の修正は src/flavors/apple-safari/preview/usePreviewEngine.ts の loop()/stopAll() / param interface と回帰テストのみで、プレビュー再生経路 (境界キック、WebAudio ルーティング、silent prewarm 廃止) には一切手を入れていません。"
+        "description": "今回の修正は iosSafariMediaRecorder.ts (エクスポート) と apple-safari startEngine の onResult ハンドラのみで、プレビュー再生経路 (境界キック、WebAudio ルーティング、silent prewarm 廃止) には一切手を入れていません。"
       }
     ]
   }


### PR DESCRIPTION
## 報告された症状

v5.1.16 がマージされた後も、実機 iPhone Safari でエクスポート完了後にダウンロードボタン (緑) へ切り替わらず、「保存ファイルを作成中」のまま固まる退行が再現するとユーザーから報告されました。screenshots では preparing → rendering (70%) → finalizing と推移して、finalizing で永遠に止まることが確認できます。

## 根本原因

iOS Safari の MediaRecorder は `recorder.stop()` を呼んでも、

1. **`state` は `'inactive'` に遷移するが `onstop` イベントが発火しない**ケースが実機で観測されます (iOS Safari 仕様バグまたは特定条件下での挙動)
2. v5.1.15 / v5.1.16 では `requestData()` + 遅延 + `stop()` の手順は揃えていましたが、**`onstop` が発火しない問題そのものは未対応**でした
3. さらに `recorder.onerror` / `chunks=0` の経路は `finishReject` で Promise を reject していましたが、**await 側に catch が無く unhandled rejection で UI が握りつぶされる**構造になっていました

つまり「onstop が来ない」「来てもエラー時は callback が握りつぶされる」の二重退行が、UI を「保存ファイルを作成中」のまま固まらせていました。

## 修正内容 (多層防御)

### 1. iOS Safari MediaRecorder に onstop watchdog を追加

`src/flavors/apple-safari/export/iosSafariMediaRecorder.ts` に 8 秒タイムアウトの watchdog を追加:

- **200ms 間隔の state monitor** が `recorder.state === 'inactive'` を検出
- 検出時に watchdog を arm (8 秒タイマー起動)
- 8 秒経過しても `onstop` が来なかった場合、**`chunks` から手動で blob を構築**して `state.setExportUrl` + `callbacks.onRecordingStop` を発火させる
- `chunks` が空のままなら `callbacks.onRecordingError` を発火させて UI をエラー状態に復帰させる

```ts
const STOP_WATCHDOG_TIMEOUT_MS = 8000;
const armStopWatchdog = () => {
  stopWatchdogTimer = setTimeout(() => {
    if (onstopFired || settled) return;
    // 手動で blob を構築し callback を発火 (UI 救出)
    if (chunks.length === 0) {
      callbacks.onRecordingError?.('...');
      return;
    }
    const blob = new Blob(chunks, { type: profile.mimeType });
    state.setExportUrl(URL.createObjectURL(blob));
    callbacks.onRecordingStop(...);
  }, STOP_WATCHDOG_TIMEOUT_MS);
};

const stateMonitorTimer = setInterval(() => {
  if (recorder.state === 'inactive') {
    clearInterval(stateMonitorTimer);
    armStopWatchdog();
  }
}, 200);
```

### 2. MediaRecorder 戦略のエラー経路を Promise reject から callback に統一

`recorder.onerror` / `chunks=0` で従来 `finishReject` を呼んでいた経路を `callbacks.onRecordingError(message)` + `finishResolve()` に統一しました。await 側で握りつぶされる Promise reject を排除。

### 3. apple-safari startEngine の `startWebCodecsExport` 呼び出しに `.catch()` を追加

万一上記以外の経路で unhandled rejection が起きても、preview engine 側で `.catch()` が UI を中断状態に戻すフェイルセーフを追加。

これで **3 段階の救出経路**が確立されます:
1. 正常系: `recorder.onstop` 発火 → callback
2. iOS Safari onstop 不発: watchdog (8 秒後) → callback or error
3. 想定外の reject: `.catch()` → UI クリーンアップ

## 影響範囲

- 変更対象:
  - `src/flavors/apple-safari/export/iosSafariMediaRecorder.ts` (watchdog, state monitor, エラー経路統一)
  - `src/flavors/apple-safari/preview/usePreviewEngine.ts` (`.catch()` 追加)
- **プレビュー再生経路には変更なし** (v5.1.14 で確認済みの安定動作を維持)
- Standard flavor (Android/PC) には変更なし

## テスト

- 全 **429 件** / 52 ファイルのテストが pass
- 新規回帰テスト 2 件:
  - `onstop` が発火せず `state=inactive` のままでも watchdog が chunks から blob を作って完了させることを保証
  - `onstop` が発火せず chunks も空のままなら watchdog が `onRecordingError` を発火して UI を救出することを保証
- `npm run build` 通過

## Test plan

- [ ] iPhone Safari で 6 秒の動画 (BGM 無し) のエクスポート → 緑のダウンロードボタンが表示されること
- [ ] iPhone Safari で複合動画 (動画+画像+動画 など) のエクスポート → 緑のダウンロードボタンが表示されること
- [ ] BGM ありエクスポート → 緑のダウンロードボタンが表示されること
- [ ] 万一エクスポートが失敗した場合 → 「作成中」のままにならずエラー表示で復帰すること
- [ ] Android プレビュー / export に退行なし
- [ ] プレビュー再生 (v5.1.14 で確認済みの動作) に退行なし

## 申し訳ありません

v5.1.15 / v5.1.16 では原因の見立てが甘く、本質的に「onstop が発火しない」という iOS Safari のバグそのものへの対策が漏れていました。今回は watchdog という確実なセーフティネットを追加することで、たとえ iOS Safari の onstop が永遠に来なくても、必ず UI を「作成中」から復帰させる構造にしました。

https://claude.ai/code/session_01Wo972ALf8zvAwMnfiYJEW6

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wo972ALf8zvAwMnfiYJEW6)_