### PR TITLE
fix(preview): iOS Safari の画像→動画境界で future video の gesture credit 喪失による固まりを修正

### DIFF
--- a/.agents/skills/turtle-video-overview/references/implementation-patterns.md
+++ b/.agents/skills/turtle-video-overview/references/implementation-patterns.md
@@ -1951,10 +1951,28 @@
 - **対策**:
   - iOS Safari preview かつ active item が image、次 item が video、次動画が paused / `readyState < HAVE_CURRENT_DATA` の場合だけ、画像区間中に `trimStart + 0.001s` へ小さく seek して current frame 取得を促す。
   - この準備では `play()` を呼ばない。active 化した瞬間の再生開始は既存の境界キックに任せる。
-  - active item が video、previous item が image、動画音量が有効、かつ clip local time が 1.2 秒以内の場合だけ、WebAudio mix は維持しつつ native video volume を `0.001` にして video pipeline を audible 扱いにする。
+  - active item が video、previous item が image、かつ clip local time が 1.2 秒以内の場合だけ、WebAudio mix は維持しつつ native video volume を `0.001` にして video pipeline を audible 扱いにする。
   - `MediaResourceLoader` の iOS Safari video は `webkit-playsinline` を付け、親 wrapper を `overflow: visible` にして clipped parent 内に閉じ込めない。
   - seek 再開経路に残っていた future video の silent `play()` も止め、gain=0 のまま再生する経路を再導入しない。
 - **注意点**:
   - active video になった後の `currentTime` 上書きは iOS Safari で `seeking=true` 残留や映像 freeze を誘発するため、今回の小さな seek は「まだ image 区間で inactive next video」の間だけに限定する。
   - native keep-alive は 0.001 の短時間・画像 -> 動画直後に限定し、通常の WebAudio 音量制御や BGM mix へ広げない。
+  - keep-alive の目的は「映像 decode pipeline の維持」であり、ユーザー音量とは独立。`desiredVolume` では分岐させない (mute 動画 / fade-in 先頭フレーム = desiredVolume 0 でも decode 抑止は起こるため、0.001 を当てて decode だけ起こす)。WebAudio 側 gain は別途 desiredVolume に従うので mute/fade の音量挙動は崩れない。
   - video -> video 境界、export、standard/Android preview には広げない。
+
+### 13-101. iOS Safari preview は future video へ gesture credit を audible play→pause で付与する
+
+- **ファイル**: `src/flavors/apple-safari/preview/previewPlatform.ts`, `src/flavors/apple-safari/preview/usePreviewEngine.ts`, `src/test/appleSafariPreviewEngineBoundary.test.tsx`, `src/test/appleSafariFlavorRegression.test.ts`
+- **問題**:
+  - iOS Safari は「ユーザー操作 (gesture) 内で一度も unmuted `play()` されていない video 要素」の後続 `play()` を拒否することがある。
+  - `startEngine` の prewarm では v5.1.14 で silent prewarm play() を全廃したため、`fromTime` 時点の active 動画以外は gesture credit を得られず、画像 -> 動画境界での初回 `play()` (境界キック) が拒否されて paused のまま固まる (黒画面 / 映像かたまり)。
+  - これが「初回まとめ追加 (動画→画像→動画) で再現し、2 動画を一度再生してから差し込むと再現しない」差の主因。後者は先のプレビューで credit を獲得済みのため。
+  - 13-100 の prebuffer / keep-alive は decode 側を助けるが、gesture credit は復元しない。
+- **対策**:
+  - `shouldGrantPreviewGestureCreditToFutureVideo()` で「iOS preview かつ非 export かつ future video」を判定する helper を追加する。
+  - `startEngine`（gesture 内）の prewarm 直後に future video だけを 1 巡し、native volume を可聴域以下 (`PREVIEW_GESTURE_CREDIT_NATIVE_VOLUME = 0.001`)・`muted=false` にして短く `play()` -> 即 `pause()` し、gesture credit だけ取得する。
+  - v5.1.14 で freeze を起こした「gain=0 の持続 silent play」とは異なり、持続再生はしない (オーバービュー 3.3 が示す audible 代案)。位置ずれは画像区間中の prebuffer / 境界 sync が補正する。
+- **注意点**:
+  - `volume=0` だと iOS が muted 相当と見なし unmuted credit が付かないため、必ず 0.001 (>0) + `muted=false` で play() する。
+  - credit 取得 (`play()` 解決) 後は必ず `pause()` で戻す。持続再生させると v5.1.14 の映像 freeze が再発する。
+  - export / standard / Android preview には広げない。**実機での最終確認が必要**な領域 (fragile な prewarm play() 経路) のため、回帰時はまずこの pass の有無を疑う。

--- a/src/flavors/apple-safari/preview/previewPlatform.ts
+++ b/src/flavors/apple-safari/preview/previewPlatform.ts
@@ -111,6 +111,12 @@ const MIN_VIDEO_READY_STATE_FOR_CURRENT_FRAME: HTMLMediaElement['readyState'] =
     : 2;
 export const EXPORT_IMAGE_TO_VIDEO_STABILIZATION_SYNC_TOLERANCE_SEC = 0.004;
 
+// iOS Safari preview の gesture credit 付与に使う native volume。
+// 0.001 ≈ -60dB で可聴域以下だが、`muted=false` と合わせて
+// 「unmuted で play() された」と iOS に認識させ、後続 play() を解禁する。
+// `volume=0` だと iOS が muted 相当と見なし unmuted credit が付かない。
+export const PREVIEW_GESTURE_CREDIT_NATIVE_VOLUME = 0.001;
+
 /**
  * プラットフォーム capability から、プレビュー制御用の方針を組み立てる。
  */
@@ -265,6 +271,32 @@ export function shouldPrimeFutureInactiveVideoInPreview(
 }
 
 /**
+ * iOS Safari preview で future video に gesture credit を付与すべきかを返す。
+ *
+ * iOS Safari は「ユーザー操作 (gesture) 内で一度も unmuted `play()` されていない
+ * video 要素」の後続 `play()` を拒否することがある。`startEngine` の prewarm では
+ * v5.1.14 で silent prewarm play() を全廃したため、`fromTime` 時点の active 動画
+ * 以外は gesture credit を得られず、画像 -> 動画境界での初回 `play()` が拒否されて
+ * paused のまま固まる (黒画面 / 映像かたまり)。これが「初回まとめ追加 (動画→画像→
+ * 動画) で再現し、2 動画を一度再生してから差し込むと再現しない」差の主因。
+ *
+ * 復活させるのは v5.1.14 で freeze 退行を起こした「gain=0 の持続 silent play」では
+ * なく、native volume を可聴域以下 (0.001) にした上での短い `play()` -> 即 `pause()`。
+ * gesture credit だけを取り、持続再生はしない (オーバービュー 3.3 が示す audible 代案)。
+ */
+export function shouldGrantPreviewGestureCreditToFutureVideo(
+  policy: PreviewPlatformPolicy,
+  options: {
+    isExporting: boolean;
+    isFutureVideo: boolean;
+  },
+): boolean {
+  return policy.muteNativeMediaWhenAudioRouted
+    && !options.isExporting
+    && options.isFutureVideo;
+}
+
+/**
  * iOS Safari preview の video -> image -> video では、画像区間中の次動画が
  * HAVE_METADATA のまま境界に入ると、active 化後の play() は通っても Canvas に
  * 描ける current frame が間に合わず、黒画面または静止画で固まったように見える。
@@ -326,6 +358,14 @@ export function getIosSafariImageToVideoPrebufferTarget(
  * native volume が完全に 0 のままだと、画像 -> 動画直後に映像 decode だけが
  * 止まり、音声だけ進むことがある。画像 -> 動画の立ち上がりだけ微小音量を残し、
  * video pipeline を audible 扱いにする。
+ *
+ * この keep-alive の目的は「映像 decode pipeline の維持」であり、ユーザーが
+ * 意図する音量とは独立している。そのため `desiredVolume` では分岐しない:
+ *  - mute された動画 (desiredVolume=0) でも、画像 -> 動画直後の decode 抑止は
+ *    起こるため、0.001 (≈ -60dB / 可聴域以下) を当てて decode だけ起こす。
+ *  - fade-in 先頭フレーム (desiredVolume=0) でも同様に decode を立ち上げる。
+ * WebAudio 側の gain は呼び出し元で別途 desiredVolume に従って制御されるため、
+ * mute / fade の音量挙動は崩れない (native 0.001 は実質無音)。
  */
 export function getIosSafariImageToVideoNativeKeepAliveVolume(
   policy: PreviewPlatformPolicy,
@@ -347,7 +387,6 @@ export function getIosSafariImageToVideoNativeKeepAliveVolume(
     || !options.isActivePlaying
     || options.activeItemType !== 'video'
     || options.previousItemType !== 'image'
-    || options.desiredVolume <= 0
     || options.clipLocalTime < 0
     || options.clipLocalTime > keepAliveWindowSec
   ) {

--- a/src/flavors/apple-safari/preview/usePreviewEngine.ts
+++ b/src/flavors/apple-safari/preview/usePreviewEngine.ts
@@ -20,11 +20,13 @@ import { collectPlaybackBlockingVideos, findActiveTimelineItem } from '../../../
 import { isCaptionActiveAtTime } from '../../../utils/captionTimeline';
 import {
   EXPORT_IMAGE_TO_VIDEO_STABILIZATION_SYNC_TOLERANCE_SEC,
+  PREVIEW_GESTURE_CREDIT_NATIVE_VOLUME,
   getIosSafariImageToVideoNativeKeepAliveVolume,
   getIosSafariImageToVideoPrebufferTarget,
   getPreviewAudioOutputMode,
   getPreviewVideoSyncThreshold,
   shouldAttemptDeferredPreviewPlay,
+  shouldGrantPreviewGestureCreditToFutureVideo,
   shouldBlackoutVideoFadeTail,
   shouldBundlePreviewStartForWebAudioMix,
   shouldHoldFrameForImageToVideoExportTransition,
@@ -2063,6 +2065,51 @@ export function usePreviewEngine({
               // 境界キックの play() に統一する。currentTime の位置合わせと
               // audio 経路の確立 (sourceNode + applyPreviewAudioOutputState) だけ
               // 実施しておく。
+            }
+          }
+
+          // gesture credit pass:
+          // iOS Safari は「gesture 内で一度も unmuted play() されていない video」の
+          // 後続 play() を拒否することがある。active 動画以外は上の prewarm で
+          // play() しないため、画像 -> 動画境界の初回 play() が拒否されて固まる。
+          // ここで future video だけ、native volume を可聴域以下 (0.001) にして
+          // 短く play() -> 即 pause() し、gesture credit だけ取得する。
+          // v5.1.14 で freeze を起こした「gain=0 の持続 silent play」とは異なり、
+          // 持続再生はしない。位置ずれは画像区間中の prebuffer / 境界 sync が補正する。
+          prewarmCursor = 0;
+          for (const item of mediaItemsRef.current) {
+            const itemStart = prewarmCursor;
+            prewarmCursor += Math.max(0, item.duration);
+            if (item.type !== 'video') continue;
+            const isFutureVideo = itemStart - fromTime > 0.0005;
+            if (
+              !shouldGrantPreviewGestureCreditToFutureVideo(previewPlatformPolicy, {
+                isExporting: false,
+                isFutureVideo,
+              })
+            ) {
+              continue;
+            }
+            const creditEl = mediaElementsRef.current[item.id] as HTMLVideoElement | undefined;
+            if (!creditEl) continue;
+            try {
+              creditEl.defaultMuted = false;
+              creditEl.muted = false;
+              creditEl.volume = PREVIEW_GESTURE_CREDIT_NATIVE_VOLUME;
+              const creditPlay = creditEl.play();
+              if (creditPlay && typeof creditPlay.then === 'function') {
+                creditPlay
+                  .then(() => {
+                    // gesture credit を取得したら即 pause。持続 silent play
+                    // (v5.1.14 freeze) は再現させない。
+                    try { creditEl.pause(); } catch { /* ignore */ }
+                  })
+                  .catch(() => {
+                    // autoplay 拒否時は credit 未取得だが無害 (従来同様の挙動)。
+                  });
+              }
+            } catch {
+              /* ignore */
             }
           }
         }

--- a/src/test/appleSafariFlavorRegression.test.ts
+++ b/src/test/appleSafariFlavorRegression.test.ts
@@ -18,6 +18,7 @@ import {
   getPreviewAudioRoutingPlan,
   getVisibilityRecoveryPlan,
   shouldBundlePreviewStartForWebAudioMix,
+  shouldGrantPreviewGestureCreditToFutureVideo,
   shouldPrimeFutureInactiveVideoInPreview,
   shouldRecoverAudioOnlyAfterVideoBoundary,
   shouldReinitializeAudioRoute,
@@ -314,6 +315,73 @@ describe('apple-safari flavor regression', () => {
         clipLocalTime: 1.5,
       }),
     ).toBe(0);
+
+    // keep-alive の目的は映像 decode pipeline の維持であり、ユーザー音量とは独立。
+    // mute 動画 (desiredVolume=0) でも画像 -> 動画直後の decode 抑止は起こるため、
+    // 0.001 を当てて decode だけ起こす (native 0.001 は実質無音)。
+    expect(
+      getIosSafariImageToVideoNativeKeepAliveVolume(previewPolicy, {
+        isExporting: false,
+        isActivePlaying: true,
+        activeItemType: 'video',
+        previousItemType: 'image',
+        desiredVolume: 0,
+        clipLocalTime: 0.2,
+      }),
+    ).toBeCloseTo(0.001);
+
+    // fade-in 先頭フレーム (desiredVolume=0) でも decode を立ち上げる。
+    expect(
+      getIosSafariImageToVideoNativeKeepAliveVolume(previewPolicy, {
+        isExporting: false,
+        isActivePlaying: true,
+        activeItemType: 'video',
+        previousItemType: 'image',
+        desiredVolume: 0,
+        clipLocalTime: 0,
+      }),
+    ).toBeCloseTo(0.001);
+  });
+
+  it('apple-safari preview は future video にだけ gesture credit を付与する (active/past/non-iOS は対象外)', () => {
+    const previewCapabilities = getAppleSafariPreviewPlatformCapabilities(createCapabilities());
+    const previewPolicy = appleSafariPreviewRuntime.getPreviewPlatformPolicy(previewCapabilities);
+
+    // future video: gesture 内で一度も play() されないため credit を付与する。
+    expect(
+      shouldGrantPreviewGestureCreditToFutureVideo(previewPolicy, {
+        isExporting: false,
+        isFutureVideo: true,
+      }),
+    ).toBe(true);
+
+    // active / past video は対象外 (active は別経路で play() 済み)。
+    expect(
+      shouldGrantPreviewGestureCreditToFutureVideo(previewPolicy, {
+        isExporting: false,
+        isFutureVideo: false,
+      }),
+    ).toBe(false);
+
+    // export 経路では gesture credit pass を動かさない。
+    expect(
+      shouldGrantPreviewGestureCreditToFutureVideo(previewPolicy, {
+        isExporting: true,
+        isFutureVideo: true,
+      }),
+    ).toBe(false);
+
+    // standard (非 iOS) policy では常に false。
+    const standardPolicy = appleSafariPreviewRuntime.getPreviewPlatformPolicy({
+      ...previewCapabilities,
+      isIosSafari: false,
+    });
+    expect(
+      shouldGrantPreviewGestureCreditToFutureVideo(standardPolicy, {
+        isExporting: false,
+        isFutureVideo: true,
+      }),
+    ).toBe(false);
   });
 
   it('apple-safari preview は BGM 無しの単独 video でも WebAudio 経路を強制し audio node 作成を促す', () => {

--- a/src/test/appleSafariPreviewEngineBoundary.test.tsx
+++ b/src/test/appleSafariPreviewEngineBoundary.test.tsx
@@ -143,6 +143,17 @@ function createMockVideoElement() {
   return element;
 }
 
+function createMockAudioContext() {
+  return {
+    state: 'running' as AudioContextState,
+    currentTime: 0,
+    destination: {} as AudioDestinationNode,
+    onstatechange: null as null | (() => void),
+    resume: vi.fn(() => Promise.resolve()),
+    suspend: vi.fn(() => Promise.resolve()),
+  } as unknown as AudioContext;
+}
+
 function createMockCanvasContext() {
   return {
     canvas: { width: 1280, height: 720 },
@@ -174,10 +185,13 @@ describe('apple-safari preview engine boundary kick', () => {
     activeVideoIdRef?: MutableRefObject<string | null>;
     isPlayingRef?: MutableRefObject<boolean>;
     isSeekingRef?: MutableRefObject<boolean>;
+    getAudioContext?: () => AudioContext;
   }) {
     const canvasContext = createMockCanvasContext();
     const logInfo = vi.fn();
     const logWarn = vi.fn();
+    const play = vi.fn();
+    const pause = vi.fn();
     const platformCapabilities = getAppleSafariPreviewPlatformCapabilities(createCapabilities());
     const previewPlatformPolicy = appleSafariPreviewRuntime.getPreviewPlatformPolicy(
       platformCapabilities,
@@ -238,9 +252,9 @@ describe('apple-safari preview engine boundary kick', () => {
         setExportExt: vi.fn(),
         clearExport: vi.fn(),
         setError: vi.fn(),
-        play: vi.fn(),
-        pause: vi.fn(),
-        getAudioContext: vi.fn(),
+        play,
+        pause,
+        getAudioContext: options.getAudioContext ?? vi.fn(),
         cancelPendingPausedSeekWait: vi.fn(),
         cancelPendingSeekPlaybackPrepare: vi.fn(),
         detachGlobalSeekEndListeners: vi.fn(),
@@ -263,7 +277,7 @@ describe('apple-safari preview engine boundary kick', () => {
       }),
     );
 
-    return { canvasContext, hook, logInfo, logWarn, activeVideoIdRef };
+    return { canvasContext, hook, logInfo, logWarn, activeVideoIdRef, play, pause };
   }
 
   it('動画→動画境界で 2 本目の active video に対し 1 度だけ境界キックを掛ける', () => {
@@ -367,6 +381,66 @@ describe('apple-safari preview engine boundary kick', () => {
     expect(video2El.play).not.toHaveBeenCalled();
     expect(video2El.currentTime).toBeGreaterThan(0);
     expect(video2El.currentTime).toBeLessThan(0.01);
+  });
+
+  it('preview startEngine は future video に gesture credit (play→pause) を付与する', async () => {
+    const rafSpy = vi
+      .spyOn(globalThis, 'requestAnimationFrame')
+      .mockImplementation(() => 1 as unknown as number);
+    vi.spyOn(globalThis, 'cancelAnimationFrame').mockImplementation(() => { });
+
+    try {
+      const video1 = createVideoItem({ id: 'v1', duration: 2 });
+      const imageGap = createImageItem({ id: 'img', duration: 1 });
+      const video2 = createVideoItem({ id: 'v2', duration: 2 });
+      const video1El = createMockVideoElement();
+      const video2El = createMockVideoElement();
+      // メタデータ済み (readyState=2) で待機を発生させない。
+      video1El.readyState = 2;
+      video1El.duration = 2;
+      video2El.readyState = 2;
+      video2El.duration = 2;
+
+      // gesture credit は play() 呼び出し時点の native volume / muted で決まる
+      // (renderFrame が後段で音量を正規化するため、呼び出し時点の値を捕捉する)。
+      const creditPlayVolumes: number[] = [];
+      const creditPlayMuted: boolean[] = [];
+      video2El.play.mockImplementation(() => {
+        creditPlayVolumes.push(video2El.volume);
+        creditPlayMuted.push(video2El.muted);
+        video2El.paused = false;
+        return Promise.resolve();
+      });
+
+      const { hook, play } = setupRenderFrameHarness({
+        mediaItems: [video1, imageGap, video2],
+        mediaElements: {
+          [video1.id]: video1El as unknown as HTMLVideoElement,
+          [video2.id]: video2El as unknown as HTMLVideoElement,
+        } as MediaElementsRef,
+        activeVideoIdRef: createRef<string | null>(null),
+        getAudioContext: () => createMockAudioContext(),
+      });
+
+      const startPromise = hook.result.current.startEngine(0, false);
+      // startEngine 内の各 await / setTimeout(50ms) を消化する。
+      await vi.advanceTimersByTimeAsync(100);
+      await startPromise;
+
+      // future video (v2) は gesture 内で credit 用に play() される。
+      expect(video2El.play).toHaveBeenCalled();
+      // credit 取得後は持続再生せず pause() で戻す (v5.1.14 freeze を再現させない)。
+      expect(video2El.pause).toHaveBeenCalled();
+      expect(video2El.paused).toBe(true);
+      // credit 用の play() は可聴域以下 (0.001) かつ unmuted で呼ばれている
+      // (volume=0 / muted=true だと unmuted credit が付かない)。
+      expect(creditPlayVolumes.some((v) => Math.abs(v - 0.001) < 0.0005)).toBe(true);
+      expect(creditPlayMuted.every((m) => m === false)).toBe(true);
+      // engine 全体の再生も開始している。
+      expect(play).toHaveBeenCalled();
+    } finally {
+      rafSpy.mockRestore();
+    }
   });
 
   it('境界キックの canplay リスナー発火で 2 本目の動画を play() する', () => {


### PR DESCRIPTION
- shouldGrantPreviewGestureCreditToFutureVideo を追加し、startEngine の
  gesture 内で future video を native volume 0.001(可聴域以下)+unmuted で
  短く play()→即 pause() して gesture credit だけ取得する。v5.1.14 で
  freeze を起こした gain=0 の持続 silent play とは異なり持続再生はしない。
  動画→画像→動画 を初回まとめ追加した際、2 本目の境界 play() が iOS の
  autoplay policy で拒否され paused のまま固まる退行を解消する。
- getIosSafariImageToVideoNativeKeepAliveVolume の desiredVolume ゲートを
  撤去。keep-alive の目的は映像 decode pipeline 維持でユーザー音量とは独立
  なため、mute 動画 / fade-in 先頭フレームでも decode を立ち上げる。
- 回帰テストを追加(future video の credit 付与、mute/fade の keep-alive)。

https://claude.ai/code/session_015QMxJ6QMLVEVZJyjA3KyhC